### PR TITLE
fix Slippi includes on Linux

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -4,6 +4,7 @@
 
 #include "Core/HW/EXI_DeviceSlippi.h"
 
+#include <SlippiGame.h>
 #include <array>
 #include <unordered_map>
 #include <stdexcept>
@@ -13,7 +14,6 @@
 #include <share.h>
 #endif
 
-#include "SlippiLib/SlippiGame.h"
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.h
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
+#include <SlippiGame.h>
 #include <string>
 #include <unordered_map>
 #include <deque>
 #include <ctime>
 
-#include "SlippiLib/SlippiGame.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
 #include "Core/HW/EXI_Device.h"


### PR DESCRIPTION
I moved them up a bit since that's where other external includes seem to be listed.