### PR TITLE
update CMakeLists to not break on non MacOS 10.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,7 +296,7 @@ if(APPLE)
 	# Note that the SDK determines the maximum version of which optional
 	# features can be used, not the minimum required version to run.
 	set(OSX_MIN_VERSION "10.9")
-	set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk")
+	set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
 	set(TARGET_FLAGS "${TARGET_FLAGS} -mmacosx-version-min=${OSX_MIN_VERSION}")
 	# Do not warn about frameworks that are not available on all architectures.
 	# This avoids a warning when linking with QuickTime.


### PR DESCRIPTION
Hi! I'm just starting to contribute.

I cloned the repo and was tryin to build on my Macbook Pro running Mojave. Unfortunately it didn't work out of the box. When I ran the `cmake ..` command, I got an error in building, as shown in: 
[fm-slippi-build.log](https://github.com/project-slippi/Ishiiruka/files/2921778/fm-slippi-build.log)

Specifically, there was a lot of errors like:
```
-- Looking for sys/types.h
CMake Warning at /usr/local/Cellar/cmake/3.12.4/share/cmake/Modules/Platform/Darwin-Initialize.cmake:125 (message):
  Ignoring CMAKE_OSX_SYSROOT value:

   /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk

  because the directory does not exist.
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.12.4/share/cmake/Modules/CMakeSystemSpecificInitialize.cmake:21 (include)
  /Users/louie/projects/melee/Ishiiruka/build/CMakeFiles/CMakeTmp/CMakeLists.txt:3 (project)
```

That value was set in CMakeLists.txt, but that SDK didn't exist for me since I'm on OS 10.14.

I think this change is safe, because looking at that directory, it looks like I have `MacOSX10.14.sdk` as a symlink to the `MacOSX.sdk`.

I'm guessing this is intended as an alias so programs can refer to this SDK without having to worry about versioning, so I think this should work for everyone. It did for me.