### PR TITLE
add std::cout signal on start and ending frames

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -1061,8 +1061,21 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 
 	// If loading from queue, move on to the next replay if we have past endFrame
 	auto watchSettings = replayComm->current;
+	if (frameIndex == watchSettings.startFrame)
+	{
+		std::cout << "[GAME_START]" << std::endl;
+	}
+
+	// This is exactly where the Game! text shows, not when the game really finishes.
+	// Should actually wait 114 frames to send the signal in order to be completely accurate.
+	if (frameIndex == watchSettings.endFrame - 124)
+	{
+		std::cout << "[GAME!]" << std::endl;
+	}
+
 	if (frameIndex > watchSettings.endFrame)
 	{
+		std::cout << "[END_FRAME]" << std::endl;
 		INFO_LOG(SLIPPI, "Killing game because we are past endFrame");
 		m_read_queue.push_back(FRAME_RESP_TERMINATE);
 		return;
@@ -1152,6 +1165,7 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 
 		if (requestResultCode == FRAME_RESP_TERMINATE)
 		{
+			std::cout << "[LRAS]" << std::endl;
 			ERROR_LOG(EXPANSIONINTERFACE, "Game should terminate on frame %d [%X]", frameIndex, frameIndex);
 		}
 


### PR DESCRIPTION
Simple but good enough way to communicate via stdout about replays playback starting/ending. Used by Slippi2Video to start/stop recording.