### PR TITLE
Fix for ambiguous argument

### DIFF
--- a/Source/Core/DolphinWX/WxUtils.cpp
+++ b/Source/Core/DolphinWX/WxUtils.cpp
@@ -153,13 +153,13 @@ void SetWindowSizeAndFitToScreen(wxTopLevelWindow* tlw, wxPoint pos, wxSize size
 	if (wxDisplay::GetCount() > 1)
 		screen_geometry = GetVirtualScreenGeometry();
 	else
-		screen_geometry = wxDisplay(0).GetClientArea();
+		screen_geometry = wxDisplay().GetClientArea();
 
 	// Initialize the default size if it is wxDefaultSize or otherwise negative.
 	default_size.DecTo(screen_geometry.GetSize());
 	default_size.IncTo(tlw->GetMinSize());
 	if (!default_size.IsFullySpecified())
-		default_size.SetDefaults(wxDisplay(0).GetClientArea().GetSize() / 2);
+		default_size.SetDefaults(wxDisplay().GetClientArea().GetSize() / 2);
 
 	// If the position we're given doesn't make sense then go with the current position.
 	// (Assuming the window was created with wxDefaultPosition then this should be reasonable)


### PR DESCRIPTION
In some environments (Fedora 30 with wxGTK3.1 and GTK3 in my case), passing 0 in these places is an ambiguous argument:
```
candidate: ‘wxDisplay::wxDisplay(const wxDisplay&)’
candidate: ‘wxDisplay::wxDisplay(const wxWindow*)’
‘wxDisplay::wxDisplay(unsigned int)’
```

We want the third one, as per the definition `wxDisplay(unsigned n = 0);`