### PR TITLE
Allow the use of savestates in solo NetPlay lobbies

### DIFF
--- a/Source/Core/DolphinWX/WxUtils.cpp
+++ b/Source/Core/DolphinWX/WxUtils.cpp
@@ -153,13 +153,13 @@ void SetWindowSizeAndFitToScreen(wxTopLevelWindow* tlw, wxPoint pos, wxSize size
 	if (wxDisplay::GetCount() > 1)
 		screen_geometry = GetVirtualScreenGeometry();
 	else
-		screen_geometry = wxDisplay(0).GetClientArea();
+		screen_geometry = wxDisplay().GetClientArea();
 
 	// Initialize the default size if it is wxDefaultSize or otherwise negative.
 	default_size.DecTo(screen_geometry.GetSize());
 	default_size.IncTo(tlw->GetMinSize());
 	if (!default_size.IsFullySpecified())
-		default_size.SetDefaults(wxDisplay(0).GetClientArea().GetSize() / 2);
+		default_size.SetDefaults(wxDisplay().GetClientArea().GetSize() / 2);
 
 	// If the position we're given doesn't make sense then go with the current position.
 	// (Assuming the window was created with wxDefaultPosition then this should be reasonable)


### PR DESCRIPTION
Gives the possibility to load saved states in NetPlay, but exclusively in solo NetPlay lobbies. This is useful because then you can use the NetPlay buffer to increase input lag but still have to possibility of using savestates.