### PR TITLE
Add some missing declarations to enable compiling on Linux

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.h
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.h
@@ -129,6 +129,13 @@ class CEXISlippi : public IEXIDevice
 	int32_t lastFFWFrame = INT_MIN;
 	std::vector<u8> m_read_queue;
 	Slippi::SlippiGame *m_current_game = nullptr;
+	bool g_inSlippiPlayback = false;
+	int g_currentPlaybackFrame = 0;
+	bool g_shouldRunThreads = false;
+	bool g_shouldJumpBack = false;
+	bool g_shouldJumpForward = false;
+	int g_targetFrameNum = INT_MAX;
+	int g_latestFrame = 0;
 
   protected:
 	void TransferByte(u8 &byte) override;


### PR DESCRIPTION
Hey,

I was trying to compile the seek functionality branch on Linux and hacked this together, now the branch compiles for me. I didn't yet check if the compiled dolphin actually works (E: playback gets stuck on go! screen). Also I'm not sure if the default values I set in the header file are correct or if they even need to be set in the first place.