### PR TITLE
Save replays under the directory where the dolphin binary is

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -22,6 +22,7 @@
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
 #include "Common/FileUtil.h"
+#include "Common/CommonPaths.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
@@ -350,8 +351,9 @@ void CEXISlippi::createNewFile()
 		closeFile();
 	}
 
-	File::CreateDir("Slippi");
-	std::string filepath = generateFileName();
+	std::string dirpath = File::GetExeDirectory();
+	File::CreateDir(dirpath + DIR_SEP + "Slippi");
+	std::string filepath = dirpath + DIR_SEP + generateFileName();
 
 	INFO_LOG(SLIPPI, "EXI_DeviceSlippi.cpp: Creating new replay file %s", filepath.c_str());
 

--- a/Source/Core/Core/Slippi/SlippiReplayComm.cpp
+++ b/Source/Core/Core/Slippi/SlippiReplayComm.cpp
@@ -1,6 +1,6 @@
 #include "SlippiReplayComm.h"
 #include "Common/FileUtil.h"
-
+#include "Common/CommonPaths.h"
 #include "Common/Logging/LogManager.h"
 #include "Core/ConfigManager.h"
 
@@ -116,8 +116,9 @@ Slippi::SlippiGame *SlippiReplayComm::loadGame()
 
 		if (commFileSettings.outputOverlayFiles)
 		{
-			File::WriteStringToFile(ws.gameStation, "Slippi/out-station.txt");
-			File::WriteStringToFile(ws.gameStartAt, "Slippi/out-time.txt");
+			std::string dirpath = File::GetExeDirectory();
+			File::WriteStringToFile(ws.gameStation, dirpath + DIR_SEP + "Slippi/out-station.txt");
+			File::WriteStringToFile(ws.gameStartAt, dirpath + DIR_SEP + "Slippi/out-time.txt");
 		}
 
 		current = ws;


### PR DESCRIPTION
Currently the location where replays are saved depends on where the dolphin was started from, with this PR replays will always be in `Slippi` directory under the directory where the dolphin binary and dolphin config files are.

The slippi comm files will also be created in the same Slippi directory