### PR TITLE
Add command line option to specify filename for dumps

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -217,6 +217,8 @@ void StartAudioDump()
 {
   std::string audio_file_name_dtk = File::GetUserPath(D_DUMPAUDIO_IDX) + "dtkdump.wav";
   std::string audio_file_name_dsp = File::GetUserPath(D_DUMPAUDIO_IDX) + "dspdump.wav";
+  if (!SConfig::GetInstance().m_strOutputFilenameBase.empty())
+    audio_file_name_dsp = SConfig::GetInstance().m_strOutputFilenameBase + ".wav";
   File::CreateFullPath(audio_file_name_dtk);
   File::CreateFullPath(audio_file_name_dsp);
   g_sound_stream->GetMixer()->StartLogDTKAudio(audio_file_name_dtk);

--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -218,7 +218,7 @@ void StartAudioDump()
   std::string audio_file_name_dtk = File::GetUserPath(D_DUMPAUDIO_IDX) + "dtkdump.wav";
   std::string audio_file_name_dsp = File::GetUserPath(D_DUMPAUDIO_IDX) + "dspdump.wav";
   if (!SConfig::GetInstance().m_strOutputFilenameBase.empty())
-    audio_file_name_dsp = SConfig::GetInstance().m_strOutputFilenameBase + ".wav";
+	  audio_file_name_dsp = File::GetUserPath(D_DUMPAUDIO_IDX) + SConfig::GetInstance().m_strOutputFilenameBase + ".wav";
   File::CreateFullPath(audio_file_name_dtk);
   File::CreateFullPath(audio_file_name_dsp);
   g_sound_stream->GetMixer()->StartLogDTKAudio(audio_file_name_dtk);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -233,6 +233,7 @@ struct SConfig : NonCopyable
 
 	std::string m_strVideoBackend;
 	std::string m_strSlippiInput;
+	std::string m_strOutputFilenameBase;
 	std::string m_strGPUDeterminismMode;
 
 	// set based on the string version

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -136,15 +136,20 @@ bool DolphinApp::OnInit()
 	else
 		SConfig::GetInstance().m_strSlippiInput = "Slippi/playback.txt";
 
+#ifdef IS_PLAYBACK
 	if (m_hide_seekbar) // Hide seekbar if necessary by cmd line (mostly for external recording applications)
 	{
 		m_prev_seekbar = SConfig::GetInstance().m_InterfaceSeekbar;
 		SConfig::GetInstance().m_InterfaceSeekbar = false;
 	}
-#ifdef IS_PLAYBACK
+
 	if (m_enable_cout) // Enable cout if necessary by cmd line (mostly for external recording applications)
 		SConfig::GetInstance().m_coutEnabled = true;
 #endif
+
+	if (m_select_output_filename_base && !m_output_filename_base.empty())
+		SConfig::GetInstance().m_strOutputFilenameBase = WxStrToStr(m_output_filename_base);
+
 	if (m_select_audio_emulation)
 		SConfig::GetInstance().bDSPHLE = (m_audio_emulation_name.Upper() == "HLE");
 
@@ -243,6 +248,8 @@ void DolphinApp::OnInitCmdLine(wxCmdLineParser& parser)
 			 wxCMD_LINE_PARAM_OPTIONAL},
 			{wxCMD_LINE_OPTION, "i", "slippi-input", "Path to Slippi replay config file (default: Slippi/playback.txt)", 
 			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
+			{wxCMD_LINE_OPTION, "o", "output-filename-base", "Base of filenames for audio and video dump files", 
+			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
 			{wxCMD_LINE_OPTION, "a", "audio_emulation", "Low level (LLE) or high level (HLE) audio",
 			 wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
 #ifdef IS_PLAYBACK
@@ -316,6 +323,7 @@ bool DolphinApp::OnCmdLineParsed(wxCmdLineParser& parser)
 	m_select_slippi_input = parser.Found("slippi-input", &m_slippi_input_name);
 	m_hide_seekbar = parser.Found("hide-seekbar");
 	m_enable_cout = parser.Found("cout");
+	m_select_output_filename_base = parser.Found("output-filename-base", &m_output_filename_base);
 	m_play_movie = parser.Found("movie", &m_movie_file);
 	parser.Found("user", &m_user_path);
 

--- a/Source/Core/DolphinWX/Main.h
+++ b/Source/Core/DolphinWX/Main.h
@@ -48,6 +48,7 @@ private:
 	bool m_use_logger = false;
 	bool m_select_video_backend = false;
 	bool m_select_slippi_input = false;
+	bool m_select_output_filename_base = false;
 	bool m_select_audio_emulation = false;
 	bool m_hide_seekbar = false;
 	bool m_prev_seekbar = false;
@@ -56,6 +57,7 @@ private:
 	wxString m_video_backend_name;
 	wxString m_audio_emulation_name;
 	wxString m_slippi_input_name;
+	wxString m_output_filename_base;
 	wxString m_user_path;
 	wxString m_file_to_load;
 	wxString m_movie_file;

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -98,6 +98,9 @@ bool AVIDump::Start(int w, int h, bool fromBGRA)
 
 static std::string GetDumpPath(const std::string& format)
 {
+	if (!SConfig::GetInstance().m_strOutputFilenameBase.empty())
+		return SConfig::GetInstance().m_strOutputFilenameBase + "." + format;
+
 	if (!g_Config.sDumpPath.empty())
 		return g_Config.sDumpPath;
 

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -98,14 +98,17 @@ bool AVIDump::Start(int w, int h, bool fromBGRA)
 
 static std::string GetDumpPath(const std::string& format)
 {
-	if (!SConfig::GetInstance().m_strOutputFilenameBase.empty())
-		return SConfig::GetInstance().m_strOutputFilenameBase + "." + format;
-
 	if (!g_Config.sDumpPath.empty())
 		return g_Config.sDumpPath;
 
-	std::string s_dump_path = File::GetUserPath(D_DUMPFRAMES_IDX) + "framedump" +
-		std::to_string(s_file_index) + "." + format;
+	std::string s_dump_path;
+
+	if (!SConfig::GetInstance().m_strOutputFilenameBase.empty())
+		s_dump_path = File::GetUserPath(D_DUMPFRAMES_IDX) + 
+			SConfig::GetInstance().m_strOutputFilenameBase + "." + format;
+	else
+		s_dump_path = File::GetUserPath(D_DUMPFRAMES_IDX) + "framedump" +
+			std::to_string(s_file_index) + "." + format;
 
 	// Ask to delete file
 	if (File::Exists(s_dump_path))


### PR DESCRIPTION
Usage:
```
./dolphin-emu -o FILENAME_BASE
```
The result is that the frame and audio dumps will be output to `{FILENAME_BASE}.avi` and `{FILENAME_BASE}.wav`, respectively.