### PR TITLE
Send playback relevant messages over cout to help with automation

### DIFF
--- a/Externals/SlippiLib/SlippiGame.cpp
+++ b/Externals/SlippiLib/SlippiGame.cpp
@@ -557,4 +557,8 @@ namespace Slippi {
   bool SlippiGame::DoesPlayerExist(int8_t port) {
     return game->settings.players.find(port) != game->settings.players.end();
   }
+
+  uint8_t SlippiGame::getGameEndMethod() {
+      return game->winCondition;
+  }
 }

--- a/Externals/SlippiLib/SlippiGame.h
+++ b/Externals/SlippiLib/SlippiGame.h
@@ -126,6 +126,7 @@ namespace Slippi {
     FrameData* GetFrameAt(uint32_t pos);
     int32_t GetLatestIndex();
     GameSettings* GetSettings();
+    uint8_t getGameEndMethod();
     bool DoesPlayerExist(int8_t port);
     bool IsProcessingComplete();
   private:

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -135,7 +135,7 @@ struct SConfig : NonCopyable
 	bool m_slippiSaveReplays = true;
 	bool m_slippiReplayMonthFolders = false;
 	std::string m_strSlippiReplayDir;
-	bool m_meleeUserIniBootstrapped = false;
+	bool m_coutEnabled = false;
 
 	bool bDPL2Decoder = false;
 	bool bTimeStretching = false;

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -1167,12 +1167,14 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 
 	// If loading from queue, move on to the next replay if we have past endFrame
 	auto watchSettings = g_replayComm->current;
-	if (watchSettings.startFrame == frameIndex)
+	if (!outputCurrentFrame && frameIndex >= watchSettings.startFrame)
 		outputCurrentFrame = true;
 	if (outputCurrentFrame)
+	{
 		std::cout << "[CURRENT_FRAME] " << frameIndex << std::endl;
-	if (watchSettings.endFrame >= frameIndex)
-		outputCurrentFrame = false;
+		if (frameIndex >= watchSettings.endFrame)
+			outputCurrentFrame = false;
+	}
 
 	if (frameIndex > watchSettings.endFrame)
 	{

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -1404,9 +1404,12 @@ void CEXISlippi::prepareIsFileReady()
 	}
 
 	auto lastFrame = m_current_game->GetFrameCount();
+	auto gameEndMethod = m_current_game->getGameEndMethod();
 	auto watchSettings = replayComm->current;
 	auto replayCommSettings = replayComm->getSettings();
 	std::cout << "[FILE_PATH] " << watchSettings.path << std::endl;
+	if (gameEndMethod == 0 || gameEndMethod == 7)
+		std::cout << "[LRAS]" << std::endl;
 	std::cout << "[PLAYBACK_START_FRAME] " << watchSettings.startFrame << std::endl;
 	std::cout << "[GAME_END_FRAME] " << lastFrame << std::endl;
 	std::cout << "[PLAYBACK_END_FRAME] " << watchSettings.endFrame << std::endl;

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -106,7 +106,7 @@ CEXISlippi::CEXISlippi()
 
 	generator = std::default_random_engine(Common::Timer::GetTimeMs());
 
-	notMirroring = replayComm->getSettings().mode != "mirror";
+	notMirroring = g_replayComm->getSettings().mode != "mirror";
 
 	// Loggers will check 5 bytes, make sure we own that memory
 	m_read_queue.reserve(5);
@@ -1169,6 +1169,7 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 
 	// If loading from queue, move on to the next replay if we have past endFrame
 	auto watchSettings = g_replayComm->current;
+#ifdef IS_PLAYBACK
 	if (notMirroring && !outputCurrentFrame && frameIndex >= watchSettings.startFrame)
 		outputCurrentFrame = true;
 	if (notMirroring && outputCurrentFrame)
@@ -1177,7 +1178,7 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 		if (frameIndex >= watchSettings.endFrame)
 			outputCurrentFrame = false;
 	}
-
+#endif
 	if (frameIndex > watchSettings.endFrame)
 	{
 		INFO_LOG(SLIPPI, "Killing game because we are past endFrame");
@@ -1404,12 +1405,13 @@ void CEXISlippi::prepareIsFileReady()
 		m_read_queue.push_back(0);
 		return;
 	}
+#ifdef IS_PLAYBACK
 	if (notMirroring)
 	{
-		auto lastFrame = m_current_game->GetFrameCount();
+		auto lastFrame = m_current_game->GetLatestIndex();
 		auto gameEndMethod = m_current_game->getGameEndMethod();
-		auto watchSettings = replayComm->current;
-		auto replayCommSettings = replayComm->getSettings();
+		auto watchSettings = g_replayComm->current;
+		auto replayCommSettings = g_replayComm->getSettings();
 		std::cout << "[FILE_PATH] " << watchSettings.path << std::endl;
 		if (gameEndMethod == 0 || gameEndMethod == 7)
 			std::cout << "[LRAS]" << std::endl;
@@ -1417,7 +1419,7 @@ void CEXISlippi::prepareIsFileReady()
 		std::cout << "[GAME_END_FRAME] " << lastFrame << std::endl;
 		std::cout << "[PLAYBACK_END_FRAME] " << watchSettings.endFrame << std::endl;
 	}
-
+#endif
 	INFO_LOG(SLIPPI, "EXI_DeviceSlippi.cpp: Replay file loaded successfully!?");
 
 	// Clear playback control related vars

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -1167,21 +1167,11 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 
 	// If loading from queue, move on to the next replay if we have past endFrame
 	auto watchSettings = g_replayComm->current;
-	if (frameIndex == watchSettings.startFrame)
-	{
-		std::cout << "[GAME_START]" << std::endl;
-	}
 
-	// This is exactly where the Game! text shows, not when the game really finishes.
-	// Should actually wait 114 frames to send the signal in order to be completely accurate.
-	if (frameIndex == watchSettings.endFrame - 124)
-	{
-		std::cout << "[GAME!]" << std::endl;
-	}
+	std::cout << "[CURRENT FRAME] " << frameIndex << std::endl;
 
 	if (frameIndex > watchSettings.endFrame)
 	{
-		std::cout << "[END_FRAME]" << std::endl;
 		INFO_LOG(SLIPPI, "Killing game because we are past endFrame");
 		m_read_queue.push_back(FRAME_RESP_TERMINATE);
 		return;
@@ -1407,6 +1397,12 @@ void CEXISlippi::prepareIsFileReady()
 		m_read_queue.push_back(0);
 		return;
 	}
+
+	auto lastFrame = m_current_game->GetFrameCount();
+	auto watchSettings = replayComm->current;
+	std::cout << "[PLAYBACK_START_FRAME] " << watchSettings.startFrame << std::endl;
+	std::cout << "[GAME_END_FRAME] " << lastFrame << std::endl;
+	std::cout << "[PLAYBACK_END_FRAME] " << watchSettings.endFrame << std::endl;
 
 	INFO_LOG(SLIPPI, "EXI_DeviceSlippi.cpp: Replay file loaded successfully!?");
 

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -1167,8 +1167,12 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 
 	// If loading from queue, move on to the next replay if we have past endFrame
 	auto watchSettings = g_replayComm->current;
-
-	std::cout << "[CURRENT_FRAME] " << frameIndex << std::endl;
+	if (watchSettings.startFrame == frameIndex)
+		startFrameOutput = true;
+	if (startFrameOutput)
+		std::cout << "[CURRENT_FRAME] " << frameIndex << std::endl;
+	if (watchSettings.endFrame == frameIndex)
+		startFrameOutput = false;
 
 	if (frameIndex > watchSettings.endFrame)
 	{
@@ -1265,7 +1269,6 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 
 		if (requestResultCode == FRAME_RESP_TERMINATE)
 		{
-			std::cout << "[LRAS]" << std::endl;
 			ERROR_LOG(EXPANSIONINTERFACE, "Game should terminate on frame %d [%X]", frameIndex, frameIndex);
 		}
 

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -1167,8 +1167,21 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 
 	// If loading from queue, move on to the next replay if we have past endFrame
 	auto watchSettings = g_replayComm->current;
+	if (frameIndex == watchSettings.startFrame)
+	{
+		std::cout << "[GAME_START]" << std::endl;
+	}
+
+	// This is exactly where the Game! text shows, not when the game really finishes.
+	// Should actually wait 114 frames to send the signal in order to be completely accurate.
+	if (frameIndex == watchSettings.endFrame - 124)
+	{
+		std::cout << "[GAME!]" << std::endl;
+	}
+
 	if (frameIndex > watchSettings.endFrame)
 	{
+		std::cout << "[END_FRAME]" << std::endl;
 		INFO_LOG(SLIPPI, "Killing game because we are past endFrame");
 		m_read_queue.push_back(FRAME_RESP_TERMINATE);
 		return;
@@ -1262,6 +1275,7 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 
 		if (requestResultCode == FRAME_RESP_TERMINATE)
 		{
+			std::cout << "[LRAS]" << std::endl;
 			ERROR_LOG(EXPANSIONINTERFACE, "Game should terminate on frame %d [%X]", frameIndex, frameIndex);
 		}
 

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -1168,7 +1168,7 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 	// If loading from queue, move on to the next replay if we have past endFrame
 	auto watchSettings = g_replayComm->current;
 
-	std::cout << "[CURRENT FRAME] " << frameIndex << std::endl;
+	std::cout << "[CURRENT_FRAME] " << frameIndex << std::endl;
 
 	if (frameIndex > watchSettings.endFrame)
 	{

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -106,7 +106,7 @@ CEXISlippi::CEXISlippi()
 
 	generator = std::default_random_engine(Common::Timer::GetTimeMs());
 
-	notMirroring = g_replayComm->getSettings().mode != "mirror";
+	shouldOutput = SConfig::GetInstance().m_coutEnabled && g_replayComm->getSettings().mode != "mirror";
 
 	// Loggers will check 5 bytes, make sure we own that memory
 	m_read_queue.reserve(5);
@@ -1170,9 +1170,9 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 	// If loading from queue, move on to the next replay if we have past endFrame
 	auto watchSettings = g_replayComm->current;
 #ifdef IS_PLAYBACK
-	if (notMirroring && !outputCurrentFrame && frameIndex >= watchSettings.startFrame)
+	if (shouldOutput && !outputCurrentFrame && frameIndex >= watchSettings.startFrame)
 		outputCurrentFrame = true;
-	if (notMirroring && outputCurrentFrame)
+	if (shouldOutput && outputCurrentFrame)
 	{
 		std::cout << "[CURRENT_FRAME] " << frameIndex << std::endl;
 		if (frameIndex >= watchSettings.endFrame)
@@ -1406,7 +1406,7 @@ void CEXISlippi::prepareIsFileReady()
 		return;
 	}
 #ifdef IS_PLAYBACK
-	if (notMirroring)
+	if (shouldOutput)
 	{
 		auto lastFrame = m_current_game->GetLatestIndex();
 		auto gameEndMethod = m_current_game->getGameEndMethod();

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -106,6 +106,8 @@ CEXISlippi::CEXISlippi()
 
 	generator = std::default_random_engine(Common::Timer::GetTimeMs());
 
+	notMirroring = replayComm->getSettings().mode != "mirror";
+
 	// Loggers will check 5 bytes, make sure we own that memory
 	m_read_queue.reserve(5);
 
@@ -1167,9 +1169,9 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 
 	// If loading from queue, move on to the next replay if we have past endFrame
 	auto watchSettings = g_replayComm->current;
-	if (!outputCurrentFrame && frameIndex >= watchSettings.startFrame)
+	if (notMirroring && !outputCurrentFrame && frameIndex >= watchSettings.startFrame)
 		outputCurrentFrame = true;
-	if (outputCurrentFrame)
+	if (notMirroring && outputCurrentFrame)
 	{
 		std::cout << "[CURRENT_FRAME] " << frameIndex << std::endl;
 		if (frameIndex >= watchSettings.endFrame)
@@ -1402,17 +1404,19 @@ void CEXISlippi::prepareIsFileReady()
 		m_read_queue.push_back(0);
 		return;
 	}
-
-	auto lastFrame = m_current_game->GetFrameCount();
-	auto gameEndMethod = m_current_game->getGameEndMethod();
-	auto watchSettings = replayComm->current;
-	auto replayCommSettings = replayComm->getSettings();
-	std::cout << "[FILE_PATH] " << watchSettings.path << std::endl;
-	if (gameEndMethod == 0 || gameEndMethod == 7)
-		std::cout << "[LRAS]" << std::endl;
-	std::cout << "[PLAYBACK_START_FRAME] " << watchSettings.startFrame << std::endl;
-	std::cout << "[GAME_END_FRAME] " << lastFrame << std::endl;
-	std::cout << "[PLAYBACK_END_FRAME] " << watchSettings.endFrame << std::endl;
+	if (notMirroring)
+	{
+		auto lastFrame = m_current_game->GetFrameCount();
+		auto gameEndMethod = m_current_game->getGameEndMethod();
+		auto watchSettings = replayComm->current;
+		auto replayCommSettings = replayComm->getSettings();
+		std::cout << "[FILE_PATH] " << watchSettings.path << std::endl;
+		if (gameEndMethod == 0 || gameEndMethod == 7)
+			std::cout << "[LRAS]" << std::endl;
+		std::cout << "[PLAYBACK_START_FRAME] " << watchSettings.startFrame << std::endl;
+		std::cout << "[GAME_END_FRAME] " << lastFrame << std::endl;
+		std::cout << "[PLAYBACK_END_FRAME] " << watchSettings.endFrame << std::endl;
+	}
 
 	INFO_LOG(SLIPPI, "EXI_DeviceSlippi.cpp: Replay file loaded successfully!?");
 

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -1168,11 +1168,11 @@ void CEXISlippi::prepareFrameData(u8 *payload)
 	// If loading from queue, move on to the next replay if we have past endFrame
 	auto watchSettings = g_replayComm->current;
 	if (watchSettings.startFrame == frameIndex)
-		startFrameOutput = true;
-	if (startFrameOutput)
+		outputCurrentFrame = true;
+	if (outputCurrentFrame)
 		std::cout << "[CURRENT_FRAME] " << frameIndex << std::endl;
-	if (watchSettings.endFrame == frameIndex)
-		startFrameOutput = false;
+	if (watchSettings.endFrame >= frameIndex)
+		outputCurrentFrame = false;
 
 	if (frameIndex > watchSettings.endFrame)
 	{
@@ -1403,6 +1403,8 @@ void CEXISlippi::prepareIsFileReady()
 
 	auto lastFrame = m_current_game->GetFrameCount();
 	auto watchSettings = replayComm->current;
+	auto replayCommSettings = replayComm->getSettings();
+	std::cout << "[FILE_PATH] " << watchSettings.path << std::endl;
 	std::cout << "[PLAYBACK_START_FRAME] " << watchSettings.startFrame << std::endl;
 	std::cout << "[GAME_END_FRAME] " << lastFrame << std::endl;
 	std::cout << "[PLAYBACK_END_FRAME] " << watchSettings.endFrame << std::endl;

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.h
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.h
@@ -123,6 +123,7 @@ class CEXISlippi : public IEXIDevice
 
 	//cout stuff
 	bool outputCurrentFrame = false;
+	bool notMirroring = false;
 
 	// vars for metadata generation
 	time_t gameStartTime;

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.h
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.h
@@ -122,7 +122,7 @@ class CEXISlippi : public IEXIDevice
 	u32 writtenByteCount = 0;
 
 	//cout stuff
-	bool startFrameOutput = false;
+	bool outputCurrentFrame = false;
 
 	// vars for metadata generation
 	time_t gameStartTime;

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.h
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.h
@@ -121,6 +121,9 @@ class CEXISlippi : public IEXIDevice
 	// .slp File creation stuff
 	u32 writtenByteCount = 0;
 
+	//cout stuff
+	bool startFrameOutput = false;
+
 	// vars for metadata generation
 	time_t gameStartTime;
 	s32 lastFrame;

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.h
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.h
@@ -123,7 +123,7 @@ class CEXISlippi : public IEXIDevice
 
 	//cout stuff
 	bool outputCurrentFrame = false;
-	bool notMirroring = false;
+	bool shouldOutput = false;
 
 	// vars for metadata generation
 	time_t gameStartTime;

--- a/Source/Core/Core/Slippi/SlippiReplayComm.cpp
+++ b/Source/Core/Core/Slippi/SlippiReplayComm.cpp
@@ -85,12 +85,11 @@ void SlippiReplayComm::nextReplay()
 {
 	if (commFileSettings.queue.empty())
 	{
-		if (!wasEmpty) std::cout << "[NO_GAME]" << std::endl;
-		wasEmpty = true;
+		if (!queueWasEmpty) std::cout << "[NO_GAME]" << std::endl;
+		queueWasEmpty = true;
 		return;
 	}
 
-	wasEmpty = false;
 	// Increment queue position
 	commFileSettings.queue.pop();
 }
@@ -200,7 +199,7 @@ void SlippiReplayComm::loadFile()
 	commFileSettings.isRealTimeMode = res.value("isRealTimeMode", false);
 	commFileSettings.rollbackDisplayMethod = res.value("rollbackDisplayMethod", "off");
 
-	if (isFirstLoad)
+	if (commFileSettings.mode == "queue")
 	{
 		auto queue = res["queue"];
 		if (queue.is_array())
@@ -219,8 +218,8 @@ void SlippiReplayComm::loadFile()
 
 				commFileSettings.queue.push(w);
 			};
-		}
 
-		isFirstLoad = false;
+			queueWasEmpty = false;
+		}
 	}
 }

--- a/Source/Core/Core/Slippi/SlippiReplayComm.cpp
+++ b/Source/Core/Core/Slippi/SlippiReplayComm.cpp
@@ -84,8 +84,13 @@ bool SlippiReplayComm::isNewReplay()
 void SlippiReplayComm::nextReplay()
 {
 	if (commFileSettings.queue.empty())
+	{
+		if (!wasEmpty) std::cout << "[NO_GAME]" << std::endl;
+		wasEmpty = true;
 		return;
+	}
 
+	wasEmpty = false;
 	// Increment queue position
 	commFileSettings.queue.pop();
 }

--- a/Source/Core/Core/Slippi/SlippiReplayComm.cpp
+++ b/Source/Core/Core/Slippi/SlippiReplayComm.cpp
@@ -85,8 +85,10 @@ void SlippiReplayComm::nextReplay()
 {
 	if (commFileSettings.queue.empty())
 	{
+#ifdef IS_PLAYBACK
 		if (!queueWasEmpty) std::cout << "[NO_GAME]" << std::endl;
 		queueWasEmpty = true;
+#endif
 		return;
 	}
 

--- a/Source/Core/Core/Slippi/SlippiReplayComm.h
+++ b/Source/Core/Core/Slippi/SlippiReplayComm.h
@@ -57,10 +57,7 @@ class SlippiReplayComm
 	u64 configLastLoadModTime;
 
 	// Queue stuff
-	bool isFirstLoad = true;
-	bool provideNew = false;
-	bool wasEmpty = true;
-	int queuePos = 0;
+	bool queueWasEmpty = true;
 
 	CommSettings commFileSettings;
 };

--- a/Source/Core/Core/Slippi/SlippiReplayComm.h
+++ b/Source/Core/Core/Slippi/SlippiReplayComm.h
@@ -59,6 +59,7 @@ class SlippiReplayComm
 	// Queue stuff
 	bool isFirstLoad = true;
 	bool provideNew = false;
+	bool wasEmpty = true;
 	int queuePos = 0;
 
 	CommSettings commFileSettings;

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -141,7 +141,10 @@ bool DolphinApp::OnInit()
 		m_prev_seekbar = SConfig::GetInstance().m_InterfaceSeekbar;
 		SConfig::GetInstance().m_InterfaceSeekbar = false;
 	}
-
+#ifdef IS_PLAYBACK
+	if (m_enable_cout) // Enable cout if necessary by cmd line (mostly for external recording applications)
+		SConfig::GetInstance().m_coutEnabled = true;
+#endif
 	if (m_select_audio_emulation)
 		SConfig::GetInstance().bDSPHLE = (m_audio_emulation_name.Upper() == "HLE");
 
@@ -242,8 +245,12 @@ void DolphinApp::OnInitCmdLine(wxCmdLineParser& parser)
 			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
 			{wxCMD_LINE_OPTION, "a", "audio_emulation", "Low level (LLE) or high level (HLE) audio",
 			 wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
+#ifdef IS_PLAYBACK
 			{wxCMD_LINE_SWITCH, "hs", "hide-seekbar", "Hide seekbar during playback", wxCMD_LINE_VAL_NONE,
 			 wxCMD_LINE_PARAM_OPTIONAL},
+			 {wxCMD_LINE_SWITCH, "co", "cout", "Enable cout during playback", wxCMD_LINE_VAL_NONE,
+			 wxCMD_LINE_PARAM_OPTIONAL},
+#endif
 			{wxCMD_LINE_OPTION, "m", "movie", "Play a movie file", wxCMD_LINE_VAL_STRING,
 			 wxCMD_LINE_PARAM_OPTIONAL},
 			{wxCMD_LINE_OPTION, "u", "user", "User folder path", wxCMD_LINE_VAL_STRING,
@@ -308,6 +315,7 @@ bool DolphinApp::OnCmdLineParsed(wxCmdLineParser& parser)
 	m_select_audio_emulation = parser.Found("audio_emulation", &m_audio_emulation_name);
 	m_select_slippi_input = parser.Found("slippi-input", &m_slippi_input_name);
 	m_hide_seekbar = parser.Found("hide-seekbar");
+	m_enable_cout = parser.Found("cout");
 	m_play_movie = parser.Found("movie", &m_movie_file);
 	parser.Found("user", &m_user_path);
 

--- a/Source/Core/DolphinWX/Main.h
+++ b/Source/Core/DolphinWX/Main.h
@@ -51,6 +51,7 @@ private:
 	bool m_select_audio_emulation = false;
 	bool m_hide_seekbar = false;
 	bool m_prev_seekbar = false;
+	bool m_enable_cout = false;
 	wxString m_confirm_setting;
 	wxString m_video_backend_name;
 	wxString m_audio_emulation_name;


### PR DESCRIPTION
[PLAYBACK_START_FRAME] sends with it the startFrame in the comm file
default: -123
usage: save value for checking with `current_frame`

[PLAYBACK_END_FRAME] sends with it the endFrame in the comm file
default: INT_MAX
usage: save value for checking with `current_frame`

[GAME_END_FRAME] sends with it the last frame number of the file
Usage: check if value is less than `playback_end_frame` to determine if you need to set `playback_end_frame` to the value received. This covers the full game case because we send INT_MAX if no endFrame is present for a queue item.

[CURRENT_FRAME] sends with it the frameIndex
Usage: check if current frame is the playback_start_frame, or playback end frame to determine if you need to start, pause, or unpause the recording.
Note: only outputted from [PLAYBACK_START_FRAME] to [PLAYBACK_END_FRAME]

[NO_GAME] indicates that there are no games left in the queue
usage: stop recording when received.

[FILE_PATH] sends with it the path to the replay file
Usage: keeping track of what file you're dealing with (you could also keep track by getting the next queue item when the `playback_end_frame` is hit)

[LRAS] indicates that the game was terminated by LRAS
Usage: avoid waiting for game if this is sent

Using these you can decide when to start recording, pause recording, unpause recording, and stop recording. This will help automate set recordings and combo video recordings.

This also adds the ability to watch different queues back to back and reload to the start of the same queue.