### PR TITLE
Minor UI fixes for games list in macOS dark mode.

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -349,16 +349,16 @@ CFrame::CFrame(wxFrame *parent, wxWindowID id, const wxString &title, wxRect geo
 	// This panel is the parent for rendering and it holds the gamelistctrl
 	m_Panel = new wxPanel(this, IDM_MPANEL, wxDefaultPosition, wxDefaultSize, 0);
 
-    // macOS dark mode with a sunken border produces a striking white border around 
-    // the game list. wxSIMPLE_BORDER looks fine in both macOS light/dark mode.
+	// macOS dark mode with a sunken border produces a striking white border around 
+	// the game list. wxSIMPLE_BORDER looks fine in both macOS light/dark mode.
 #ifdef __WXOSX__
-    long game_list_style = wxLC_REPORT | wxSIMPLE_BORDER | wxLC_ALIGN_LEFT; 
+	long game_list_style = wxLC_REPORT | wxSIMPLE_BORDER | wxLC_ALIGN_LEFT; 
 #else
-    long game_list_style = wxLC_REPORT | wxSUNKEN_BORDER | wxLC_ALIGN_LEFT;
+	long game_list_style = wxLC_REPORT | wxSUNKEN_BORDER | wxLC_ALIGN_LEFT;
 #endif
 
 	m_GameListCtrl = new CGameListCtrl(m_Panel, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-	                                   game_list_style);
+										game_list_style);
 	m_GameListCtrl->Bind(wxEVT_LIST_ITEM_ACTIVATED, &CFrame::OnGameListCtrlItemActivated, this);
 
 	wxBoxSizer *sizerPanel = new wxBoxSizer(wxHORIZONTAL);

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -349,8 +349,16 @@ CFrame::CFrame(wxFrame *parent, wxWindowID id, const wxString &title, wxRect geo
 	// This panel is the parent for rendering and it holds the gamelistctrl
 	m_Panel = new wxPanel(this, IDM_MPANEL, wxDefaultPosition, wxDefaultSize, 0);
 
+    // macOS dark mode with a sunken border produces a striking white border around 
+    // the game list. wxSIMPLE_BORDER looks fine in both macOS light/dark mode.
+#ifdef __WXOSX__
+    long game_list_style = wxLC_REPORT | wxSIMPLE_BORDER | wxLC_ALIGN_LEFT; 
+#else
+    long game_list_style = wxLC_REPORT | wxSUNKEN_BORDER | wxLC_ALIGN_LEFT;
+#endif
+
 	m_GameListCtrl = new CGameListCtrl(m_Panel, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-	                                   wxLC_REPORT | wxSUNKEN_BORDER | wxLC_ALIGN_LEFT);
+	                                   game_list_style);
 	m_GameListCtrl->Bind(wxEVT_LIST_ITEM_ACTIVATED, &CFrame::OnGameListCtrlItemActivated, this);
 
 	wxBoxSizer *sizerPanel = new wxBoxSizer(wxHORIZONTAL);

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -529,16 +529,16 @@ static wxColour blend50(const wxColour& c1, const wxColour& c2)
 void CGameListCtrl::SetBackgroundColor()
 {
 #ifdef __WXOSX__
-    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
-    wxColour alt = appearance.IsDark() ? wxSystemSettings::GetColour(wxSYS_COLOUR_3DDKSHADOW) :
-        wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT);
+	wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
+	wxColour alt_color = appearance.IsDark() ? wxSystemSettings::GetColour(wxSYS_COLOUR_3DDKSHADOW) :
+		wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT);
 #else
-    wxColour alt = wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT);
+	wxColour alt_color = wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT);
 #endif
 
 	for (long i = 0; i < GetItemCount(); i++)
 	{
-		wxColour color = (i & 1) ? blend50(alt, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW)) :
+		wxColour color = (i & 1) ? blend50(alt_color, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW)) :
 			wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
 		CGameListCtrl::SetItemBackgroundColour(i, color);
 	}

--- a/Source/Core/DolphinWX/GameListCtrl.cpp
+++ b/Source/Core/DolphinWX/GameListCtrl.cpp
@@ -528,10 +528,17 @@ static wxColour blend50(const wxColour& c1, const wxColour& c2)
 
 void CGameListCtrl::SetBackgroundColor()
 {
+#ifdef __WXOSX__
+    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
+    wxColour alt = appearance.IsDark() ? wxSystemSettings::GetColour(wxSYS_COLOUR_3DDKSHADOW) :
+        wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT);
+#else
+    wxColour alt = wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT);
+#endif
+
 	for (long i = 0; i < GetItemCount(); i++)
 	{
-		wxColour color = (i & 1) ? blend50(wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT),
-			wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW)) :
+		wxColour color = (i & 1) ? blend50(alt, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW)) :
 			wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
 		CGameListCtrl::SetItemBackgroundColour(i, color);
 	}


### PR DESCRIPTION
These aren't _super_ important but they're quality-of-life if you have a games list your client is pulling from. Kept the changes as un-intrusive as possible.

- on macOS, swaps the border from sunken to simple. In dark mode, sunken
  appears as a thick white border around the frame, simple is thin and
  mostly unnoticeable in both light and dark mode.

- In the games list, if the platform is macOS, it does a check to see if
  it's currently rendering in dark mode or not. If it is, it'll opt to
  blend the 3D shadow color instead of the 3D light color. Doing this
  keeps the games list legible at a glance... granted, less of an isue
  since this is mostly for running Melee only, but if you have a games
  list from regular Dolphin and it carries over to here, it can be a bit
  jarring.

Before:

_(Edit: I realized I took this with the sunken border swapped, whoops)_

![Screen Shot 2020-06-23 at 17 19 44](https://user-images.githubusercontent.com/22712/85481372-8cba2800-b576-11ea-98b5-5810b9187298.png)

After:

<img width="639" alt="Screen Shot 2020-06-23 at 17 20 53" src="https://user-images.githubusercontent.com/22712/85481391-9479cc80-b576-11ea-8152-52b8cb65aaa8.png">
