### PR TITLE
Automatically fix users saving their .json as .json.txt

### DIFF
--- a/Source/Core/Core/Slippi/SlippiUser.cpp
+++ b/Source/Core/Core/Slippi/SlippiUser.cpp
@@ -55,6 +55,18 @@ bool SlippiUser::AttemptLogin()
 
 	INFO_LOG(SLIPPI_ONLINE, "Looking for file at: %s", userFilePath.c_str());
 
+	{
+		std::string userFilePathTxt = userFilePath + ".txt"; //Put the filename here in its own scope because we don't really need it elsewhere
+		if (File::Exists(userFilePathTxt) && File::Exists(userFilePath))
+		{
+			INFO_LOG(SLIPPI_ONLINE, "Found both .txt and .json file for user data. Using .json");
+		}
+		else if (File::Exists(userFilePathTxt))
+		{
+			File::Rename(userFilePathTxt, userFilePath);
+		}
+	}
+
 	// Get user file
 	std::string userFileContents;
 	File::ReadFileToString(userFilePath, userFileContents);
@@ -169,6 +181,7 @@ std::string SlippiUser::getUserFilePath()
 #else
 	std::string dirPath = File::GetExeDirectory();
 #endif
+
 	std::string userFilePath = dirPath + DIR_SEP + "user.json";
 	return userFilePath;
 }

--- a/Source/Core/Core/Slippi/SlippiUser.cpp
+++ b/Source/Core/Core/Slippi/SlippiUser.cpp
@@ -56,14 +56,25 @@ bool SlippiUser::AttemptLogin()
 	INFO_LOG(SLIPPI_ONLINE, "Looking for file at: %s", userFilePath.c_str());
 
 	{
-		std::string userFilePathTxt = userFilePath + ".txt"; //Put the filename here in its own scope because we don't really need it elsewhere
+		std::string userFilePathTxt = userFilePath + ".txt"; // Put the filename here in its own scope because we don't really need it elsewhere
+		// If both files exist we just log they exist and take no further action
 		if (File::Exists(userFilePathTxt) && File::Exists(userFilePath))
 		{
-			INFO_LOG(SLIPPI_ONLINE, "Found both .txt and .json file for user data. Using .json");
+			INFO_LOG(SLIPPI_ONLINE, "Found both .json.txt and .json file for user data. Using .json and ignoring the .json.txt");
 		}
+		// If only the .txt file exists copy the contents to a json file and delete the text file
 		else if (File::Exists(userFilePathTxt))
 		{
-			File::Rename(userFilePathTxt, userFilePath);
+			// Attempt to copy the txt file to the json file path. If it fails log a warning
+			if (!File::Copy(userFilePathTxt, userFilePath))
+			{
+				WARN_LOG(SLIPPI_ONLINE, "Could not copy file %s to %s", userFilePathTxt.c_str(), userFilePath.c_str());
+			}
+			// Attempt to delete the txt file. If it fails log an info because this isn't as critical
+			if (!File::Delete(userFilePathTxt))
+			{
+				INFO_LOG(SLIPPI_ONLINE, "Failed to delete %s", userFilePathTxt.c_str());
+			}
 		}
 	}
 


### PR DESCRIPTION
Added check to see if the user data file was accidentally saved as "user.json.txt" and to effectively rename it to "user.json" if it was.