### PR TITLE
Unix update msg

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -1980,11 +1980,13 @@ void CEXISlippi::handleLogOutRequest()
 
 void CEXISlippi::handleUpdateAppRequest()
 {
-//#ifndef LINUX_LOCAL_DEV
+#ifdef _WIN32
 	main_frame->LowerRenderWindow();
 	user->UpdateApp();
 	main_frame->DoExit();
-//#endif
+#else
+	CriticalAlertT("Automatic updates are not available for macOS and Linux, please update manually.");
+#endif
 }
 
 void CEXISlippi::prepareOnlineStatus()


### PR DESCRIPTION
Let macOS and Linux users know that they have to manually update right now.

This can be tested by manually changing the `user.json`'s version number to something higher.