### PR TITLE
Add the ability to disable replays and set replay directory path

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -595,7 +595,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("SlippiOnlineDelay", &m_slippiOnlineDelay, 2);
 	core->Get("SlippiSaveReplays", &m_slippiSaveReplays, true);
 	core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
-		File::GetExeDirectory() + DIR_SEP + "Slippi/");
+		File::GetExeDirectory() + DIR_SEP + "Slippi");
 	core->Get("MemcardAPath", &m_strMemoryCardA);
 	core->Get("MemcardBPath", &m_strMemoryCardB);
 	core->Get("AgpCartAPath", &m_strGbaCartA);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -594,8 +594,13 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("Latency", &iLatency, 2);
 	core->Get("SlippiOnlineDelay", &m_slippiOnlineDelay, 2);
 	core->Get("SlippiSaveReplays", &m_slippiSaveReplays, true);
-	core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
-		File::GetExeDirectory() + DIR_SEP + "Slippi");
+	#ifdef _WIN32
+		core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
+			File::GetExeDirectory() + "\\" + "Slippi");
+	#else
+		core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
+			File::GetExeDirectory() + DIR_SEP + "Slippi");
+	#endif
 	core->Get("MemcardAPath", &m_strMemoryCardA);
 	core->Get("MemcardBPath", &m_strMemoryCardB);
 	core->Get("AgpCartAPath", &m_strGbaCartA);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -276,6 +276,8 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 	core->Set("RSHACK", bRSHACK);
 	core->Set("Latency", iLatency);
 	core->Set("SlippiOnlineDelay", m_slippiOnlineDelay);
+	core->Set("SlippiSaveReplays", m_slippiSaveReplays);
+	core->Set("SlippiReplayDir", m_strSlippiReplayDir);
 	core->Set("MemcardAPath", m_strMemoryCardA);
 	core->Set("MemcardBPath", m_strMemoryCardB);
 	core->Set("AgpCartAPath", m_strGbaCartA);
@@ -591,6 +593,9 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("RSHACK", &bRSHACK, false);
 	core->Get("Latency", &iLatency, 2);
 	core->Get("SlippiOnlineDelay", &m_slippiOnlineDelay, 2);
+	core->Get("SlippiSaveReplays", &m_slippiSaveReplays, true);
+	core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
+		File::GetExeDirectory() + DIR_SEP + "Slippi/");
 	core->Get("MemcardAPath", &m_strMemoryCardA);
 	core->Get("MemcardBPath", &m_strMemoryCardB);
 	core->Get("AgpCartAPath", &m_strGbaCartA);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -131,6 +131,9 @@ struct SConfig : NonCopyable
     bool bHasShownLagReductionWarning = false;
     bool bMeleeForceWidescreen = false;
 
+	bool m_slippiSaveReplays = true;
+	std::string m_strSlippiReplayDir;
+
 	bool bDPL2Decoder = false;
 	bool bTimeStretching = false;
 	bool bRSHACK = false;

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -508,8 +508,13 @@ void CEXISlippi::createNewFile()
 
 	std::string dirpath = SConfig::GetInstance().m_strSlippiReplayDir;
 	File::CreateDir(dirpath);
-	std::string filepath = dirpath + generateFileName();
 
+	char dirpathEnd = dirpath.back();
+	if (dirpathEnd == '/' || dirpathEnd == '\\') {
+		dirpath.pop_back();
+	}
+
+	std::string filepath = dirpath + DIR_SEP + generateFileName();
 	INFO_LOG(SLIPPI, "EXI_DeviceSlippi.cpp: Creating new replay file %s", filepath.c_str());
 
 #ifdef _WIN32

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -379,6 +379,10 @@ std::vector<u8> CEXISlippi::generateMetadata()
 
 void CEXISlippi::writeToFileAsync(u8 *payload, u32 length, std::string fileOption)
 {
+	if (!SConfig::GetInstance().m_slippiSaveReplays) {
+		return;
+	}
+
 	if (fileOption == "create" && !writeThreadRunning)
 	{
 		WARN_LOG(SLIPPI, "Creating file write thread...");
@@ -502,9 +506,9 @@ void CEXISlippi::createNewFile()
 		closeFile();
 	}
 
-	std::string dirpath = File::GetExeDirectory();
-	File::CreateDir(dirpath + DIR_SEP + "Slippi");
-	std::string filepath = dirpath + DIR_SEP + generateFileName();
+	std::string dirpath = SConfig::GetInstance().m_strSlippiReplayDir;
+	File::CreateDir(dirpath);
+	std::string filepath = dirpath + generateFileName();
 
 	INFO_LOG(SLIPPI, "EXI_DeviceSlippi.cpp: Creating new replay file %s", filepath.c_str());
 
@@ -523,7 +527,7 @@ std::string CEXISlippi::generateFileName()
 	strftime(&dateTimeBuf[0], dateTimeStrLength, "%Y%m%dT%H%M%S", localtime(&gameStartTime));
 
 	std::string str(&dateTimeBuf[0]);
-	return StringFromFormat("Slippi/Game_%s.slp", str.c_str());
+	return StringFromFormat("Game_%s.slp", str.c_str());
 }
 
 void CEXISlippi::closeFile()

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
@@ -100,10 +100,12 @@ void GameCubeConfigPane::InitializeGUI()
 	
 	// Slippi replay settings
 	m_replay_enable_checkbox = new wxCheckBox(this, wxID_ANY, _("Save Slippi Replays"));
+	m_replay_enable_checkbox->SetToolTip(
+		_("Enable this to make Slippi automatically save .slp recordings of your games."));
+
 	m_replay_directory_picker = new wxDirPickerCtrl(this, wxID_ANY, wxEmptyString, 
 		_("Choose a Slippi replay folder:"), wxDefaultPosition, wxDefaultSize, 
 		wxDIRP_USE_TEXTCTRL | wxDIRP_SMALL);
-	
 	m_replay_directory_picker->SetToolTip(
 		_("Choose where your Slippi replay files are saved."));
 

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
@@ -12,6 +12,7 @@
 #include <wx/choice.h>
 #include <wx/filedlg.h>
 #include <wx/filename.h>
+#include <wx/filepicker.h>
 #include <wx/gbsizer.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
@@ -96,6 +97,15 @@ void GameCubeConfigPane::InitializeGUI()
 		new wxButton(this, wxID_ANY, "...", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
 	m_memcard_path[1] =
 		new wxButton(this, wxID_ANY, "...", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+	
+	// Slippi replay settings
+	m_replay_enable_checkbox = new wxCheckBox(this, wxID_ANY, _("Save Slippi Replays"));
+	m_replay_directory_picker = new wxDirPickerCtrl(this, wxID_ANY, wxEmptyString, 
+		_("Choose a Slippi replay folder:"), wxDefaultPosition, wxDefaultSize, 
+		wxDIRP_USE_TEXTCTRL | wxDIRP_SMALL);
+	
+	m_replay_directory_picker->SetToolTip(
+		_("Choose where your Slippi replay files are saved."));
 
 	const int space5 = FromDIP(5);
 	const int space10 = FromDIP(10);
@@ -118,6 +128,7 @@ void GameCubeConfigPane::InitializeGUI()
 	wxStaticBoxSizer* const sbGamecubeDeviceSettings =
 		new wxStaticBoxSizer(wxVERTICAL, this, _("Device Settings"));
 	wxGridBagSizer* const gamecube_EXIDev_sizer = new wxGridBagSizer(space10, space10);
+
 	for (int i = 0; i < 3; ++i)
 	{
 		gamecube_EXIDev_sizer->Add(GCEXIDeviceText[i], wxGBPosition(i, 0), wxDefaultSpan,
@@ -133,11 +144,26 @@ void GameCubeConfigPane::InitializeGUI()
 	sbGamecubeDeviceSettings->Add(gamecube_EXIDev_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
 	sbGamecubeDeviceSettings->AddSpacer(space5);
 
+	wxGridBagSizer* const sGamecubeReplaySettings = new wxGridBagSizer(space5, space5);
+	sGamecubeReplaySettings->Add(m_replay_enable_checkbox, wxGBPosition(0, 0), wxGBSpan(1, 2));
+	sGamecubeReplaySettings->Add(new wxStaticText(this, wxID_ANY, _("Replay folder:")), wxGBPosition(1, 0),
+		wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
+	sGamecubeReplaySettings->Add(m_replay_directory_picker, wxGBPosition(1, 1), wxDefaultSpan, wxEXPAND);
+	sGamecubeReplaySettings->AddGrowableCol(1);
+
+	wxStaticBoxSizer* const sbGamecubeReplaySettings =
+		new wxStaticBoxSizer(wxVERTICAL, this, _("Slippi Replay Settings"));
+	sbGamecubeReplaySettings->AddSpacer(space5);
+	sbGamecubeReplaySettings->Add(sGamecubeReplaySettings, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
+	sbGamecubeReplaySettings->AddSpacer(space5);
+
 	wxBoxSizer* const main_sizer = new wxBoxSizer(wxVERTICAL);
 	main_sizer->AddSpacer(space5);
 	main_sizer->Add(sbGamecubeIPLSettings, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
 	main_sizer->AddSpacer(space5);
 	main_sizer->Add(sbGamecubeDeviceSettings, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
+	main_sizer->AddSpacer(space5);
+	main_sizer->Add(sbGamecubeReplaySettings, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
 	main_sizer->AddSpacer(space5);
 
 	SetSizer(main_sizer);
@@ -215,6 +241,9 @@ void GameCubeConfigPane::LoadGUIValues()
 		if (!isMemcard && !isMic && i < 2)
 			m_memcard_path[i]->Disable();
 	}
+
+	m_replay_enable_checkbox->SetValue(startup_params.m_slippiSaveReplays);
+	m_replay_directory_picker->SetPath(StrToWxStr(startup_params.m_strSlippiReplayDir));
 }
 
 void GameCubeConfigPane::BindEvents()
@@ -238,6 +267,12 @@ void GameCubeConfigPane::BindEvents()
 
 	m_memcard_path[0]->Bind(wxEVT_BUTTON, &GameCubeConfigPane::OnSlotAButtonClick, this);
 	m_memcard_path[1]->Bind(wxEVT_BUTTON, &GameCubeConfigPane::OnSlotBButtonClick, this);
+
+	m_replay_enable_checkbox->Bind(wxEVT_CHECKBOX, &GameCubeConfigPane::OnReplaySavingToggle, this);
+	m_replay_enable_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+
+	m_replay_directory_picker->Bind(wxEVT_DIRPICKER_CHANGED, &GameCubeConfigPane::OnReplayDirChanged, this);
+	m_replay_directory_picker->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 }
 
 void GameCubeConfigPane::OnSystemLanguageChange(wxCommandEvent& event)
@@ -298,6 +333,17 @@ void GameCubeConfigPane::OnSlotAButtonClick(wxCommandEvent& event)
 void GameCubeConfigPane::OnSlotBButtonClick(wxCommandEvent& event)
 {
 	HandleEXISlotChange(1, wxString(_("GameCube Microphone Slot B")));
+}
+
+void GameCubeConfigPane::OnReplaySavingToggle(wxCommandEvent& event)
+{
+	SConfig::GetInstance().m_slippiSaveReplays = m_replay_enable_checkbox->IsChecked();
+}
+
+void GameCubeConfigPane::OnReplayDirChanged(wxCommandEvent& event)
+{
+	SConfig::GetInstance().m_strSlippiReplayDir =
+		WxStrToStr(m_replay_directory_picker->GetPath());
 }
 
 void GameCubeConfigPane::ChooseEXIDevice(const wxString& deviceName, int deviceNum)

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
@@ -12,6 +12,7 @@ enum TEXIDevices : int;
 class wxButton;
 class wxCheckBox;
 class wxChoice;
+class wxDirPickerCtrl;
 class wxString;
 
 class GameCubeConfigPane final : public wxPanel
@@ -37,6 +38,9 @@ private:
 	void HandleEXISlotChange(int slot, const wxString& title);
 	void ChooseSlotPath(bool is_slot_a, TEXIDevices device_type);
 
+	void OnReplaySavingToggle(wxCommandEvent& event);
+	void OnReplayDirChanged(wxCommandEvent& event);
+
 	wxArrayString m_ipl_language_strings;
 
 	wxChoice* m_system_lang_choice;
@@ -44,4 +48,6 @@ private:
 	wxCheckBox* m_skip_bios_checkbox;
 	wxChoice* m_exi_devices[3];
 	wxButton* m_memcard_path[2];
+	wxCheckBox* m_replay_enable_checkbox;
+	wxDirPickerCtrl* m_replay_directory_picker;
 };


### PR DESCRIPTION
Fixes #42 

Config > GameCube now has settings for:

- Whether to save Slippi replay files (Default: enabled)

- Where to save Slippi replay files (Default: [directory with the Dolphin executable]/Slippi)