### PR TITLE
Add the ability to disable replays, set replay directory path, update delay frames

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -25,7 +25,9 @@
 #include <io.h>
 #include <objbase.h>  // guid stuff
 #include <shellapi.h>
+#include <ShlObj.h>
 #include <windows.h>
+#include <winerror.h>
 #else
 #include <dirent.h>
 #include <errno.h>
@@ -753,6 +755,31 @@ std::string& GetExeDirectory()
 #endif
 	}
 	return DolphinPath;
+}
+
+std::string GetHomeDirectory()
+{
+	std::string homeDir;
+#ifdef _WIN32
+	wchar_t *path = nullptr;
+	
+	if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Documents, 0, nullptr, &path))) {
+		char pathStr[MAX_PATH];
+		wcstombs(pathStr, path, MAX_PATH);
+	
+		homeDir = std::string(pathStr);
+		CoTaskMemFree(path);		
+	}
+	else {
+		const char* home = getenv("USERPROFILE");
+		homeDir = std::string(home) + "\\Documents";
+	}
+#else
+	const char* home = getenv("HOME");
+    homeDir = std::string(home);
+#endif
+
+	return homeDir;
 }
 
 std::string GetSysDirectory()

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -158,6 +158,8 @@ std::string GetBundleDirectory();
 
 std::string& GetExeDirectory();
 
+std::string GetHomeDirectory();
+
 bool WriteStringToFile(const std::string& str, const std::string& filename);
 bool ReadFileToString(const std::string& filename, std::string& str);
 

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -596,18 +596,13 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("SlippiOnlineDelay", &m_slippiOnlineDelay, 2);
 	core->Get("SlippiSaveReplays", &m_slippiSaveReplays, true);
 	core->Get("SlippiReplayMonthFolders", &m_slippiReplayMonthFolders, false);
-	#ifdef _WIN32
-		core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
-			File::GetExeDirectory() + "\\" + "Slippi");
-	#elif defined(__APPLE__)
-		std::string bundleDir = File::GetBundleDirectory();
-		std::string slpDir = bundleDir.substr(0, bundleDir.find("Dolphin.app")) + "Slippi";
-
-		core->Get("SlippiReplayDir", &m_strSlippiReplayDir, slpDir);
-	#else
-		core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
-			File::GetExeDirectory() + DIR_SEP + "Slippi");
-	#endif
+#ifdef _WIN32
+	core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
+		File::GetHomeDirectory() + "\\Slippi");
+#else
+	core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
+		File::GetHomeDirectory() + DIR_SEP + "Slippi");
+#endif
 	core->Get("MemcardAPath", &m_strMemoryCardA);
 	core->Get("MemcardBPath", &m_strMemoryCardB);
 	core->Get("AgpCartAPath", &m_strGbaCartA);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -599,6 +599,11 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	#ifdef _WIN32
 		core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
 			File::GetExeDirectory() + "\\" + "Slippi");
+	#elif defined(__APPLE__)
+		std::string bundleDir = File::GetBundleDirectory();
+		std::string slpDir = bundleDir.substr(0, bundleDir.find("Dolphin.app")) + "Slippi";
+
+		core->Get("SlippiReplayDir", &m_strSlippiReplayDir, slpDir);
 	#else
 		core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
 			File::GetExeDirectory() + DIR_SEP + "Slippi");

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -277,6 +277,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 	core->Set("Latency", iLatency);
 	core->Set("SlippiOnlineDelay", m_slippiOnlineDelay);
 	core->Set("SlippiSaveReplays", m_slippiSaveReplays);
+	core->Set("SlippiReplayMonthFolders", m_slippiReplayMonthFolders);
 	core->Set("SlippiReplayDir", m_strSlippiReplayDir);
 	core->Set("MemcardAPath", m_strMemoryCardA);
 	core->Set("MemcardBPath", m_strMemoryCardB);
@@ -594,6 +595,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("Latency", &iLatency, 2);
 	core->Get("SlippiOnlineDelay", &m_slippiOnlineDelay, 2);
 	core->Get("SlippiSaveReplays", &m_slippiSaveReplays, true);
+	core->Get("SlippiReplayMonthFolders", &m_slippiReplayMonthFolders, false);
 	#ifdef _WIN32
 		core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
 			File::GetExeDirectory() + "\\" + "Slippi");

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -594,8 +594,13 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("Latency", &iLatency, 2);
 	core->Get("SlippiOnlineDelay", &m_slippiOnlineDelay, 2);
 	core->Get("SlippiSaveReplays", &m_slippiSaveReplays, true);
-	core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
-		File::GetExeDirectory() + DIR_SEP + "Slippi/");
+	#ifdef _WIN32
+		core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
+			File::GetExeDirectory() + "\\" + "Slippi");
+	#else
+		core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
+			File::GetExeDirectory() + DIR_SEP + "Slippi");
+	#endif
 	core->Get("MemcardAPath", &m_strMemoryCardA);
 	core->Get("MemcardBPath", &m_strMemoryCardB);
 	core->Get("AgpCartAPath", &m_strGbaCartA);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -276,6 +276,8 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 	core->Set("RSHACK", bRSHACK);
 	core->Set("Latency", iLatency);
 	core->Set("SlippiOnlineDelay", m_slippiOnlineDelay);
+	core->Set("SlippiSaveReplays", m_slippiSaveReplays);
+	core->Set("SlippiReplayDir", m_strSlippiReplayDir);
 	core->Set("MemcardAPath", m_strMemoryCardA);
 	core->Set("MemcardBPath", m_strMemoryCardB);
 	core->Set("AgpCartAPath", m_strGbaCartA);
@@ -591,6 +593,9 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("RSHACK", &bRSHACK, false);
 	core->Get("Latency", &iLatency, 2);
 	core->Get("SlippiOnlineDelay", &m_slippiOnlineDelay, 2);
+	core->Get("SlippiSaveReplays", &m_slippiSaveReplays, true);
+	core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
+		File::GetExeDirectory() + DIR_SEP + "Slippi/");
 	core->Get("MemcardAPath", &m_strMemoryCardA);
 	core->Get("MemcardBPath", &m_strMemoryCardB);
 	core->Get("AgpCartAPath", &m_strGbaCartA);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -131,6 +131,9 @@ struct SConfig : NonCopyable
     bool bHasShownLagReductionWarning = false;
     bool bMeleeForceWidescreen = false;
 
+	bool m_slippiSaveReplays = true;
+	std::string m_strSlippiReplayDir;
+
 	bool bDPL2Decoder = false;
 	bool bTimeStretching = false;
 	bool bRSHACK = false;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -132,6 +132,7 @@ struct SConfig : NonCopyable
     bool bMeleeForceWidescreen = false;
 
 	bool m_slippiSaveReplays = true;
+	bool m_slippiReplayMonthFolders = false;
 	std::string m_strSlippiReplayDir;
 
 	bool bDPL2Decoder = false;

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -528,11 +528,31 @@ void CEXISlippi::createNewFile()
 	}
 
 	std::string dirpath = SConfig::GetInstance().m_strSlippiReplayDir;
+
+	// First, ensure that the root Slippi replay directory is created
 	File::CreateDir(dirpath);
 
+	// Remove a trailing / or \\ if the user managed to have that in their config
 	char dirpathEnd = dirpath.back();
 	if (dirpathEnd == '/' || dirpathEnd == '\\') {
 		dirpath.pop_back();
+	}
+
+	// Now we have a dir such as /home/Replays but we need to make one such 
+	// as /home/Replays/2020-06 if month categorization is enabled
+	if (SConfig::GetInstance().m_slippiReplayMonthFolders) {
+		dirpath.push_back('/');
+
+		// Append YYYY-MM to the directory path
+		uint8_t yearMonthStrLength = sizeof "2020-06";
+		std::vector<char> yearMonthBuf(yearMonthStrLength);
+		strftime(&yearMonthBuf[0], yearMonthStrLength, "%Y-%m", localtime(&gameStartTime));
+
+		std::string yearMonth(&yearMonthBuf[0]);
+		dirpath.append(yearMonth);
+
+		// Ensure that the subfolder directory is created
+		File::CreateDir(dirpath);
 	}
 
 	std::string filepath = dirpath + DIR_SEP + generateFileName();

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -29,6 +29,7 @@
 #include "Common/FileUtil.h"
 #include "Common/Logging/Log.h"
 #include "Common/MemoryUtil.h"
+#include "Common/MsgHandler.h"
 #include "Common/StringUtil.h"
 #include "Common/Thread.h"
 #include "Core/HW/Memmap.h"
@@ -529,14 +530,14 @@ void CEXISlippi::createNewFile()
 
 	std::string dirpath = SConfig::GetInstance().m_strSlippiReplayDir;
 
-	// First, ensure that the root Slippi replay directory is created
-	File::CreateDir(dirpath);
-
 	// Remove a trailing / or \\ if the user managed to have that in their config
 	char dirpathEnd = dirpath.back();
 	if (dirpathEnd == '/' || dirpathEnd == '\\') {
 		dirpath.pop_back();
 	}
+
+	// First, ensure that the root Slippi replay directory is created
+	File::CreateFullPath(dirpath + "/");
 
 	// Now we have a dir such as /home/Replays but we need to make one such 
 	// as /home/Replays/2020-06 if month categorization is enabled
@@ -563,6 +564,15 @@ void CEXISlippi::createNewFile()
 #else
 	m_file = File::IOFile(filepath, "wb");
 #endif
+
+	if (!m_file) {
+		PanicAlertT("Could not create .slp replay file [%s].\n\n"
+					"The replay folder's path might be invalid, or you might "
+					"not have permission to write to it.\n\n"
+					"You can change the replay folder in Config > GameCube > "
+					"Slippi Replay Settings.",
+					filepath.c_str());
+	}
 }
 
 std::string CEXISlippi::generateFileName()

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -529,8 +529,13 @@ void CEXISlippi::createNewFile()
 
 	std::string dirpath = SConfig::GetInstance().m_strSlippiReplayDir;
 	File::CreateDir(dirpath);
-	std::string filepath = dirpath + generateFileName();
 
+	char dirpathEnd = dirpath.back();
+	if (dirpathEnd == '/' || dirpathEnd == '\\') {
+		dirpath.pop_back();
+	}
+
+	std::string filepath = dirpath + DIR_SEP + generateFileName();
 	INFO_LOG(SLIPPI, "EXI_DeviceSlippi.cpp: Creating new replay file %s", filepath.c_str());
 
 #ifdef _WIN32

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -385,6 +385,10 @@ std::vector<u8> CEXISlippi::generateMetadata()
 
 void CEXISlippi::writeToFileAsync(u8 *payload, u32 length, std::string fileOption)
 {
+	if (!SConfig::GetInstance().m_slippiSaveReplays) {
+		return;
+	}
+
 	if (fileOption == "create" && !writeThreadRunning)
 	{
 		WARN_LOG(SLIPPI, "Creating file write thread...");
@@ -523,9 +527,9 @@ void CEXISlippi::createNewFile()
 		closeFile();
 	}
 
-	std::string dirpath = File::GetExeDirectory();
-	File::CreateDir(dirpath + DIR_SEP + "Slippi");
-	std::string filepath = dirpath + DIR_SEP + generateFileName();
+	std::string dirpath = SConfig::GetInstance().m_strSlippiReplayDir;
+	File::CreateDir(dirpath);
+	std::string filepath = dirpath + generateFileName();
 
 	INFO_LOG(SLIPPI, "EXI_DeviceSlippi.cpp: Creating new replay file %s", filepath.c_str());
 
@@ -544,7 +548,7 @@ std::string CEXISlippi::generateFileName()
 	strftime(&dateTimeBuf[0], dateTimeStrLength, "%Y%m%dT%H%M%S", localtime(&gameStartTime));
 
 	std::string str(&dateTimeBuf[0]);
-	return StringFromFormat("Slippi/Game_%s.slp", str.c_str());
+	return StringFromFormat("Game_%s.slp", str.c_str());
 }
 
 void CEXISlippi::closeFile()

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
@@ -117,8 +117,7 @@ void GameCubeConfigPane::InitializeGUI()
 	m_slippi_delay_frames_txt = new wxStaticText(this, wxID_ANY, _("Slippi Online Delay Frames:"));
 	m_slippi_delay_frames_ctrl = new wxSpinCtrl(this, wxID_ANY, _(std::to_string(SConfig::GetInstance().m_slippiOnlineDelay)));
 	m_slippi_delay_frames_ctrl->SetToolTip(_("Set how many delay frames you have when playing Slippi Online."));
-	m_slippi_delay_frames_ctrl->SetMin(1);
-	m_slippi_delay_frames_ctrl->SetMax(10);
+	m_slippi_delay_frames_ctrl->SetRange(1, 10);
 
 	const int space5 = FromDIP(5);
 	const int space10 = FromDIP(10);

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
@@ -100,10 +100,12 @@ void GameCubeConfigPane::InitializeGUI()
 	
 	// Slippi replay settings
 	m_replay_enable_checkbox = new wxCheckBox(this, wxID_ANY, _("Save Slippi Replays"));
+	m_replay_enable_checkbox->SetToolTip(
+		_("Enable this to make Slippi automatically save .slp recordings of your games."));
+
 	m_replay_directory_picker = new wxDirPickerCtrl(this, wxID_ANY, wxEmptyString, 
 		_("Choose a Slippi replay folder:"), wxDefaultPosition, wxDefaultSize, 
 		wxDIRP_USE_TEXTCTRL | wxDIRP_SMALL);
-	
 	m_replay_directory_picker->SetToolTip(
 		_("Choose where your Slippi replay files are saved."));
 

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
@@ -164,7 +164,7 @@ void GameCubeConfigPane::InitializeGUI()
 		wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
 	sGamecubeSlippiSettings->Add(m_replay_directory_picker, wxGBPosition(2, 1), wxDefaultSpan, wxEXPAND);
 	sGamecubeSlippiSettings->Add(m_slippi_delay_frames_txt, wxGBPosition(3, 0), wxDefaultSpan, wxEXPAND);
-	sGamecubeSlippiSettings->Add(m_slippi_delay_frames_ctrl, wxGBPosition(3, 1), wxDefaultSpan, wxALIGN_RIGHT);
+	sGamecubeSlippiSettings->Add(m_slippi_delay_frames_ctrl, wxGBPosition(3, 1), wxDefaultSpan, wxALIGN_LEFT);
 	sGamecubeSlippiSettings->AddGrowableCol(1);
 
 	wxStaticBoxSizer* const sbGamecubeSlippiSettings =

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
@@ -16,6 +16,7 @@
 #include <wx/gbsizer.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
+#include <wx/spinctrl.h>
 
 #include "Common/Common.h"
 #include "Common/CommonPaths.h"
@@ -98,21 +99,26 @@ void GameCubeConfigPane::InitializeGUI()
 	m_memcard_path[1] =
 		new wxButton(this, wxID_ANY, "...", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
 	
-	// Slippi replay settings
-	m_replay_enable_checkbox = new wxCheckBox(this, wxID_ANY, _("Save Slippi replays"));
+	// Slippi settings
+	m_replay_enable_checkbox = new wxCheckBox(this, wxID_ANY, _("Save Slippi Replays"));
 	m_replay_enable_checkbox->SetToolTip(
 		_("Enable this to make Slippi automatically save .slp recordings of your games."));
 
 	m_replay_month_folders_checkbox =
-		new wxCheckBox(this, wxID_ANY, _("Save replays to monthly subfolders"));
+		new wxCheckBox(this, wxID_ANY, _("Save Replays to Monthly Subfolders"));
 	m_replay_month_folders_checkbox->SetToolTip(
 		_("Enable this to save your replays into subfolders by month (YYYY-MM)."));
 
 	m_replay_directory_picker = new wxDirPickerCtrl(this, wxID_ANY, wxEmptyString, 
-		_("Choose a Slippi replay folder:"), wxDefaultPosition, wxDefaultSize, 
+		_("Slippi Replay Folder:"), wxDefaultPosition, wxDefaultSize, 
 		wxDIRP_USE_TEXTCTRL | wxDIRP_SMALL);
 	m_replay_directory_picker->SetToolTip(
 		_("Choose where your Slippi replay files are saved."));
+	m_slippi_delay_frames_txt = new wxStaticText(this, wxID_ANY, _("Slippi Online Delay Frames:"));
+	m_slippi_delay_frames_ctrl = new wxSpinCtrl(this, wxID_ANY, _(std::to_string(SConfig::GetInstance().m_slippiOnlineDelay)));
+	m_slippi_delay_frames_ctrl->SetToolTip(_("Set how many delay frames you have when playing Slippi Online."));
+	m_slippi_delay_frames_ctrl->SetMin(1);
+	m_slippi_delay_frames_ctrl->SetMax(10);
 
 	const int space5 = FromDIP(5);
 	const int space10 = FromDIP(10);
@@ -151,20 +157,22 @@ void GameCubeConfigPane::InitializeGUI()
 	sbGamecubeDeviceSettings->Add(gamecube_EXIDev_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
 	sbGamecubeDeviceSettings->AddSpacer(space5);
 
-	wxGridBagSizer* const sGamecubeReplaySettings = new wxGridBagSizer(space5, space5);
-	sGamecubeReplaySettings->Add(m_replay_enable_checkbox, wxGBPosition(0, 0), wxGBSpan(1, 2));
-	sGamecubeReplaySettings->Add(m_replay_month_folders_checkbox, wxGBPosition(1, 0), wxGBSpan(1, 2),
+	wxGridBagSizer* const sGamecubeSlippiSettings = new wxGridBagSizer(space5, space5);
+	sGamecubeSlippiSettings->Add(m_replay_enable_checkbox, wxGBPosition(0, 0), wxGBSpan(1, 2));
+	sGamecubeSlippiSettings->Add(m_replay_month_folders_checkbox, wxGBPosition(1, 0), wxGBSpan(1, 2),
 		wxRESERVE_SPACE_EVEN_IF_HIDDEN);
-	sGamecubeReplaySettings->Add(new wxStaticText(this, wxID_ANY, _("Replay folder:")), wxGBPosition(2, 0),
+	sGamecubeSlippiSettings->Add(new wxStaticText(this, wxID_ANY, _("Replay folder:")), wxGBPosition(2, 0),
 		wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
-	sGamecubeReplaySettings->Add(m_replay_directory_picker, wxGBPosition(2, 1), wxDefaultSpan, wxEXPAND);
-	sGamecubeReplaySettings->AddGrowableCol(1);
+	sGamecubeSlippiSettings->Add(m_replay_directory_picker, wxGBPosition(2, 1), wxDefaultSpan, wxEXPAND);
+	sGamecubeSlippiSettings->Add(m_slippi_delay_frames_txt, wxGBPosition(3, 0), wxDefaultSpan, wxEXPAND);
+	sGamecubeSlippiSettings->Add(m_slippi_delay_frames_ctrl, wxGBPosition(3, 1), wxDefaultSpan, wxALIGN_RIGHT);
+	sGamecubeSlippiSettings->AddGrowableCol(1);
 
-	wxStaticBoxSizer* const sbGamecubeReplaySettings =
-		new wxStaticBoxSizer(wxVERTICAL, this, _("Slippi Replay Settings"));
-	sbGamecubeReplaySettings->AddSpacer(space5);
-	sbGamecubeReplaySettings->Add(sGamecubeReplaySettings, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
-	sbGamecubeReplaySettings->AddSpacer(space5);
+	wxStaticBoxSizer* const sbGamecubeSlippiSettings =
+		new wxStaticBoxSizer(wxVERTICAL, this, _("Slippi Settings"));
+	sbGamecubeSlippiSettings->AddSpacer(space5);
+	sbGamecubeSlippiSettings->Add(sGamecubeSlippiSettings, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
+	sbGamecubeSlippiSettings->AddSpacer(space5);
 
 	wxBoxSizer* const main_sizer = new wxBoxSizer(wxVERTICAL);
 	main_sizer->AddSpacer(space5);
@@ -172,7 +180,7 @@ void GameCubeConfigPane::InitializeGUI()
 	main_sizer->AddSpacer(space5);
 	main_sizer->Add(sbGamecubeDeviceSettings, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
 	main_sizer->AddSpacer(space5);
-	main_sizer->Add(sbGamecubeReplaySettings, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
+	main_sizer->Add(sbGamecubeSlippiSettings, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
 	main_sizer->AddSpacer(space5);
 
 	SetSizer(main_sizer);
@@ -293,6 +301,9 @@ void GameCubeConfigPane::BindEvents()
 
 	m_replay_directory_picker->Bind(wxEVT_DIRPICKER_CHANGED, &GameCubeConfigPane::OnReplayDirChanged, this);
 	m_replay_directory_picker->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+
+	m_slippi_delay_frames_ctrl->Bind(wxEVT_SPINCTRL, &GameCubeConfigPane::OnDelayFramesChanged, this);
+	m_slippi_delay_frames_ctrl->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 }
 
 void GameCubeConfigPane::OnSystemLanguageChange(wxCommandEvent& event)
@@ -381,6 +392,11 @@ void GameCubeConfigPane::OnReplayDirChanged(wxCommandEvent& event)
 {
 	SConfig::GetInstance().m_strSlippiReplayDir =
 		WxStrToStr(m_replay_directory_picker->GetPath());
+}
+
+void GameCubeConfigPane::OnDelayFramesChanged(wxCommandEvent& event)
+{
+	SConfig::GetInstance().m_slippiOnlineDelay = m_slippi_delay_frames_ctrl->GetValue();
 }
 
 void GameCubeConfigPane::ChooseEXIDevice(const wxString& deviceName, int deviceNum)

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
@@ -115,9 +115,9 @@ void GameCubeConfigPane::InitializeGUI()
 	m_replay_directory_picker->SetToolTip(
 		_("Choose where your Slippi replay files are saved."));
 	m_slippi_delay_frames_txt = new wxStaticText(this, wxID_ANY, _("Slippi Online Delay Frames:"));
-	m_slippi_delay_frames_ctrl = new wxSpinCtrl(this, wxID_ANY, _(std::to_string(SConfig::GetInstance().m_slippiOnlineDelay)));
+	m_slippi_delay_frames_ctrl = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(50, -1));
 	m_slippi_delay_frames_ctrl->SetToolTip(_("Set how many delay frames you have when playing Slippi Online."));
-	m_slippi_delay_frames_ctrl->SetRange(1, 10);
+	m_slippi_delay_frames_ctrl->SetRange(1, 9);
 
 	const int space5 = FromDIP(5);
 	const int space10 = FromDIP(10);
@@ -267,6 +267,8 @@ void GameCubeConfigPane::LoadGUIValues()
 	if (!enableReplays) {
 		m_replay_month_folders_checkbox->Hide();
 	}
+
+	m_slippi_delay_frames_ctrl->SetValue(startup_params.m_slippiOnlineDelay);
 }
 
 void GameCubeConfigPane::BindEvents()

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
@@ -12,6 +12,7 @@
 #include <wx/choice.h>
 #include <wx/filedlg.h>
 #include <wx/filename.h>
+#include <wx/filepicker.h>
 #include <wx/gbsizer.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
@@ -96,6 +97,15 @@ void GameCubeConfigPane::InitializeGUI()
 		new wxButton(this, wxID_ANY, "...", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
 	m_memcard_path[1] =
 		new wxButton(this, wxID_ANY, "...", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+	
+	// Slippi replay settings
+	m_replay_enable_checkbox = new wxCheckBox(this, wxID_ANY, _("Save Slippi Replays"));
+	m_replay_directory_picker = new wxDirPickerCtrl(this, wxID_ANY, wxEmptyString, 
+		_("Choose a Slippi replay folder:"), wxDefaultPosition, wxDefaultSize, 
+		wxDIRP_USE_TEXTCTRL | wxDIRP_SMALL);
+	
+	m_replay_directory_picker->SetToolTip(
+		_("Choose where your Slippi replay files are saved."));
 
 	const int space5 = FromDIP(5);
 	const int space10 = FromDIP(10);
@@ -118,6 +128,7 @@ void GameCubeConfigPane::InitializeGUI()
 	wxStaticBoxSizer* const sbGamecubeDeviceSettings =
 		new wxStaticBoxSizer(wxVERTICAL, this, _("Device Settings"));
 	wxGridBagSizer* const gamecube_EXIDev_sizer = new wxGridBagSizer(space10, space10);
+
 	for (int i = 0; i < 3; ++i)
 	{
 		gamecube_EXIDev_sizer->Add(GCEXIDeviceText[i], wxGBPosition(i, 0), wxDefaultSpan,
@@ -133,11 +144,26 @@ void GameCubeConfigPane::InitializeGUI()
 	sbGamecubeDeviceSettings->Add(gamecube_EXIDev_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
 	sbGamecubeDeviceSettings->AddSpacer(space5);
 
+	wxGridBagSizer* const sGamecubeReplaySettings = new wxGridBagSizer(space5, space5);
+	sGamecubeReplaySettings->Add(m_replay_enable_checkbox, wxGBPosition(0, 0), wxGBSpan(1, 2));
+	sGamecubeReplaySettings->Add(new wxStaticText(this, wxID_ANY, _("Replay folder:")), wxGBPosition(1, 0),
+		wxDefaultSpan, wxALIGN_CENTER_VERTICAL);
+	sGamecubeReplaySettings->Add(m_replay_directory_picker, wxGBPosition(1, 1), wxDefaultSpan, wxEXPAND);
+	sGamecubeReplaySettings->AddGrowableCol(1);
+
+	wxStaticBoxSizer* const sbGamecubeReplaySettings =
+		new wxStaticBoxSizer(wxVERTICAL, this, _("Slippi Replay Settings"));
+	sbGamecubeReplaySettings->AddSpacer(space5);
+	sbGamecubeReplaySettings->Add(sGamecubeReplaySettings, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
+	sbGamecubeReplaySettings->AddSpacer(space5);
+
 	wxBoxSizer* const main_sizer = new wxBoxSizer(wxVERTICAL);
 	main_sizer->AddSpacer(space5);
 	main_sizer->Add(sbGamecubeIPLSettings, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
 	main_sizer->AddSpacer(space5);
 	main_sizer->Add(sbGamecubeDeviceSettings, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
+	main_sizer->AddSpacer(space5);
+	main_sizer->Add(sbGamecubeReplaySettings, 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
 	main_sizer->AddSpacer(space5);
 
 	SetSizer(main_sizer);
@@ -215,6 +241,9 @@ void GameCubeConfigPane::LoadGUIValues()
 		if (!isMemcard && !isMic && i < 2)
 			m_memcard_path[i]->Disable();
 	}
+
+	m_replay_enable_checkbox->SetValue(startup_params.m_slippiSaveReplays);
+	m_replay_directory_picker->SetPath(StrToWxStr(startup_params.m_strSlippiReplayDir));
 }
 
 void GameCubeConfigPane::BindEvents()
@@ -238,6 +267,12 @@ void GameCubeConfigPane::BindEvents()
 
 	m_memcard_path[0]->Bind(wxEVT_BUTTON, &GameCubeConfigPane::OnSlotAButtonClick, this);
 	m_memcard_path[1]->Bind(wxEVT_BUTTON, &GameCubeConfigPane::OnSlotBButtonClick, this);
+
+	m_replay_enable_checkbox->Bind(wxEVT_CHECKBOX, &GameCubeConfigPane::OnReplaySavingToggle, this);
+	m_replay_enable_checkbox->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
+
+	m_replay_directory_picker->Bind(wxEVT_DIRPICKER_CHANGED, &GameCubeConfigPane::OnReplayDirChanged, this);
+	m_replay_directory_picker->Bind(wxEVT_UPDATE_UI, &WxEventUtils::OnEnableIfCoreNotRunning);
 }
 
 void GameCubeConfigPane::OnSystemLanguageChange(wxCommandEvent& event)
@@ -298,6 +333,17 @@ void GameCubeConfigPane::OnSlotAButtonClick(wxCommandEvent& event)
 void GameCubeConfigPane::OnSlotBButtonClick(wxCommandEvent& event)
 {
 	HandleEXISlotChange(1, wxString(_("GameCube Microphone Slot B")));
+}
+
+void GameCubeConfigPane::OnReplaySavingToggle(wxCommandEvent& event)
+{
+	SConfig::GetInstance().m_slippiSaveReplays = m_replay_enable_checkbox->IsChecked();
+}
+
+void GameCubeConfigPane::OnReplayDirChanged(wxCommandEvent& event)
+{
+	SConfig::GetInstance().m_strSlippiReplayDir =
+		WxStrToStr(m_replay_directory_picker->GetPath());
 }
 
 void GameCubeConfigPane::ChooseEXIDevice(const wxString& deviceName, int deviceNum)

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.cpp
@@ -104,16 +104,15 @@ void GameCubeConfigPane::InitializeGUI()
 		_("Enable this to make Slippi automatically save .slp recordings of your games."));
 
 	m_replay_month_folders_checkbox =
-		new wxCheckBox(this, wxID_ANY, _("Categorize replays by month"));
+		new wxCheckBox(this, wxID_ANY, _("Save replays to monthly subfolders"));
 	m_replay_month_folders_checkbox->SetToolTip(
-		_("Enable this to categorize your replays into subfolders by month (YYYY-MM)."));
+		_("Enable this to save your replays into subfolders by month (YYYY-MM)."));
 
 	m_replay_directory_picker = new wxDirPickerCtrl(this, wxID_ANY, wxEmptyString, 
 		_("Choose a Slippi replay folder:"), wxDefaultPosition, wxDefaultSize, 
-		wxDIRP_DIR_MUST_EXIST | wxDIRP_USE_TEXTCTRL | wxDIRP_SMALL);
-	m_replay_directory_picker->SetToolTip(_(
-		"Choose where your Slippi replay files are saved. If you type in a folder"
-		" manually, make sure that folder exists."));
+		wxDIRP_USE_TEXTCTRL | wxDIRP_SMALL);
+	m_replay_directory_picker->SetToolTip(
+		_("Choose where your Slippi replay files are saved."));
 
 	const int space5 = FromDIP(5);
 	const int space10 = FromDIP(10);

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
@@ -13,6 +13,7 @@ class wxButton;
 class wxCheckBox;
 class wxChoice;
 class wxDirPickerCtrl;
+class wxSpinCtrl;
 class wxString;
 class wxStaticText;
 

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
@@ -39,6 +39,7 @@ private:
 	void ChooseSlotPath(bool is_slot_a, TEXIDevices device_type);
 
 	void OnReplaySavingToggle(wxCommandEvent& event);
+	void OnReplayMonthFoldersToggle(wxCommandEvent& event);
 	void OnReplayDirChanged(wxCommandEvent& event);
 
 	wxArrayString m_ipl_language_strings;
@@ -50,4 +51,5 @@ private:
 	wxButton* m_memcard_path[2];
 	wxCheckBox* m_replay_enable_checkbox;
 	wxDirPickerCtrl* m_replay_directory_picker;
+	wxCheckBox* m_replay_month_folders_checkbox;
 };

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
@@ -12,6 +12,7 @@ enum TEXIDevices : int;
 class wxButton;
 class wxCheckBox;
 class wxChoice;
+class wxDirPickerCtrl;
 class wxString;
 
 class GameCubeConfigPane final : public wxPanel
@@ -37,6 +38,9 @@ private:
 	void HandleEXISlotChange(int slot, const wxString& title);
 	void ChooseSlotPath(bool is_slot_a, TEXIDevices device_type);
 
+	void OnReplaySavingToggle(wxCommandEvent& event);
+	void OnReplayDirChanged(wxCommandEvent& event);
+
 	wxArrayString m_ipl_language_strings;
 
 	wxChoice* m_system_lang_choice;
@@ -44,4 +48,6 @@ private:
 	wxCheckBox* m_skip_bios_checkbox;
 	wxChoice* m_exi_devices[3];
 	wxButton* m_memcard_path[2];
+	wxCheckBox* m_replay_enable_checkbox;
+	wxDirPickerCtrl* m_replay_directory_picker;
 };

--- a/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
+++ b/Source/Core/DolphinWX/Config/GameCubeConfigPane.h
@@ -14,6 +14,7 @@ class wxCheckBox;
 class wxChoice;
 class wxDirPickerCtrl;
 class wxString;
+class wxStaticText;
 
 class GameCubeConfigPane final : public wxPanel
 {
@@ -41,6 +42,7 @@ private:
 	void OnReplaySavingToggle(wxCommandEvent& event);
 	void OnReplayMonthFoldersToggle(wxCommandEvent& event);
 	void OnReplayDirChanged(wxCommandEvent& event);
+	void OnDelayFramesChanged(wxCommandEvent &event);
 
 	wxArrayString m_ipl_language_strings;
 
@@ -52,4 +54,6 @@ private:
 	wxCheckBox* m_replay_enable_checkbox;
 	wxDirPickerCtrl* m_replay_directory_picker;
 	wxCheckBox* m_replay_month_folders_checkbox;
+	wxStaticText* m_slippi_delay_frames_txt;
+	wxSpinCtrl *m_slippi_delay_frames_ctrl;
 };


### PR DESCRIPTION
Fixes #42 
Fixes #72

Config > GameCube now has settings for:

- Whether to save Slippi replay files (Default: enabled)

- Where to save Slippi replay files (Default: [directory with the Dolphin executable]/Slippi)

- Whether to categorize Slippi replay files in YYYY-MM format subfolders (Default: disabled)

- Slippi Online Delay Frames (Default: 2)

![Screenshot_20200627_165605](https://user-images.githubusercontent.com/2197457/85932094-27787680-b897-11ea-8440-8fccbd34bb9a.png)

