### PR TITLE
Add connect code to slp metadata.

### DIFF
--- a/Source/Core/Core/Slippi/SlippiNetplay.cpp
+++ b/Source/Core/Core/Slippi/SlippiNetplay.cpp
@@ -272,6 +272,7 @@ void SlippiNetplayClient::writeToPacket(sf::Packet &packet, SlippiPlayerSelectio
 	packet << s.stageId << s.isStageSelected;
 	packet << s.rngOffset;
 	packet << s.playerName;
+	packet << s.connectCode;
 }
 
 std::unique_ptr<SlippiPlayerSelections> SlippiNetplayClient::readSelectionsFromPacket(sf::Packet &packet)
@@ -287,6 +288,7 @@ std::unique_ptr<SlippiPlayerSelections> SlippiNetplayClient::readSelectionsFromP
 
 	packet >> s->rngOffset;
 	packet >> s->playerName;
+	packet >> s->connectCode;
 
 	return std::move(s);
 }

--- a/Source/Core/Core/Slippi/SlippiNetplay.h
+++ b/Source/Core/Core/Slippi/SlippiNetplay.h
@@ -48,11 +48,13 @@ class SlippiPlayerSelections
 	u32 rngOffset = 0;
 
 	std::string playerName = "";
+	std::string connectCode = "";
 
 	void Merge(SlippiPlayerSelections &s)
 	{
 		this->rngOffset = s.rngOffset;
 		this->playerName = s.playerName;
+		this->connectCode = s.connectCode;
 
 		if (s.isStageSelected)
 		{


### PR DESCRIPTION
- Adds a new field `connectCode` to the `SlippiPlayerSelections` struct
- Adds a new field for each player in the metadata to hold the connection code

### Example recording:

[sample_with_code_metadata.zip](https://github.com/project-slippi/Ishiiruka/files/4834692/sample_with_code_metadata.zip)

#### Metadata
```
{
  '0': {
    names: { netplay: 'whoami', code: 'CARB#206' },
    characters: { '22': 1055 }
  },
  '1': {
    names: { netplay: 'MyTestingAlt', code: 'ABCD#647' },
    characters: { '1': 1055 }
  }
}
```

Fixes #59 