### PR TITLE
Use CPU count for make jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
           cd wxWidgets-3.1.3
           cd build
           ../configure
-          make -j7
+          make -j$(nproc)
           sudo make install
       - name: "Build"
         if: success()
@@ -178,7 +178,7 @@ jobs:
           mkdir build
           cd build
           cmake ..
-          make -j7
+          make -j$(nproc)
       - name: "Package Netplay"
         if: success()
         shell: bash

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -10,7 +10,7 @@ if [ ! -e "./build/" ]; then  mkdir ./build; fi
 # Move into the build directory, run CMake, and compile the project
 pushd ./build
 cmake ${CMAKE_FLAGS} ../
-make -j7
+make -j$(nproc)
 popd
 
 


### PR DESCRIPTION
Instead of defaulting to 7 for make jobs, default to the number of available CPUs using nproc.