### PR TITLE
[PR] Fix host swap failure

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -462,9 +462,9 @@ void CEXISlippi::writeToFile(std::unique_ptr<WriteMessage> msg)
 			SlippiPlayerSelections lps = matchInfo->localPlayerSelections;
 			SlippiPlayerSelections rps = matchInfo->remotePlayerSelections;
 
-			auto isHost = slippi_netplay->IsHost();
-			slippi_names[0] = isHost ? lps.playerName : rps.playerName;
-			slippi_names[1] = isHost ? rps.playerName : lps.playerName;
+			auto isDecider = slippi_netplay->IsDecider();
+			slippi_names[0] = isDecider ? lps.playerName : rps.playerName;
+			slippi_names[1] = isDecider ? rps.playerName : lps.playerName;
 		}
 	}
 
@@ -1714,9 +1714,9 @@ void CEXISlippi::prepareOnlineMatchState()
 			remotePlayerReady = matchInfo->remotePlayerSelections.isCharacterSelected;
 #endif
 
-			auto isHost = slippi_netplay->IsHost();
-			localPlayerIndex = isHost ? 0 : 1;
-			remotePlayerIndex = isHost ? 1 : 0;
+			auto isDecider = slippi_netplay->IsDecider();
+			localPlayerIndex = isDecider ? 0 : 1;
+			remotePlayerIndex = isDecider ? 1 : 0;
 
 			oppName = slippi_netplay->GetOpponentName();
 		}
@@ -1744,7 +1744,7 @@ void CEXISlippi::prepareOnlineMatchState()
 
 	if (localPlayerReady && remotePlayerReady)
 	{
-		auto isHost = slippi_netplay->IsHost();
+		auto isDecider = slippi_netplay->IsDecider();
 
 		auto matchInfo = slippi_netplay->GetMatchInfo();
 		SlippiPlayerSelections lps = matchInfo->localPlayerSelections;
@@ -1774,7 +1774,7 @@ void CEXISlippi::prepareOnlineMatchState()
 
 		// Overwrite stage
 		u16 stageId;
-		if (isHost)
+		if (isDecider)
 		{
 			stageId = lps.isStageSelected ? lps.stageId : rps.stageId;
 		}
@@ -1791,13 +1791,13 @@ void CEXISlippi::prepareOnlineMatchState()
 		*stage = Common::swap16(stageId);
 
 		// Set rng offset
-		rngOffset = isHost ? lps.rngOffset : rps.rngOffset;
+		rngOffset = isDecider ? lps.rngOffset : rps.rngOffset;
 		WARN_LOG(SLIPPI_ONLINE, "Rng Offset: 0x%x", rngOffset);
 		WARN_LOG(SLIPPI_ONLINE, "P1 Char: 0x%X, P2 Char: 0x%X", onlineMatchBlock[0x60], onlineMatchBlock[0x84]);
 
 		// Set player names
-		p1Name = isHost ? lps.playerName : rps.playerName;
-		p2Name = isHost ? rps.playerName : lps.playerName;
+		p1Name = isDecider ? lps.playerName : rps.playerName;
+		p2Name = isDecider ? rps.playerName : lps.playerName;
 	}
 
 	// Add rng offset to output

--- a/Source/Core/Core/Slippi/SlippiMatchmaking.cpp
+++ b/Source/Core/Core/Slippi/SlippiMatchmaking.cpp
@@ -427,7 +427,7 @@ void SlippiMatchmaking::handleConnecting()
 	SplitString(m_oppIp, ':', ipParts);
 
 	sendHolePunchMsg(ipParts[0], std::stoi(ipParts[1]), m_hostPort);
-	auto client = std::make_unique<SlippiNetplayClient>(ipParts[0], std::stoi(ipParts[1]), m_hostPort, false);
+	auto client = std::make_unique<SlippiNetplayClient>(ipParts[0], std::stoi(ipParts[1]), m_hostPort, m_isHost);
 
 	while (!m_netplayClient)
 	{

--- a/Source/Core/Core/Slippi/SlippiMatchmaking.cpp
+++ b/Source/Core/Core/Slippi/SlippiMatchmaking.cpp
@@ -379,54 +379,12 @@ void SlippiMatchmaking::handleMatchmaking()
 	ERROR_LOG(SLIPPI_ONLINE, "[Matchmaking] Opponent found. isDecider: %s", m_isHost ? "true" : "false");
 }
 
-void SlippiMatchmaking::sendHolePunchMsg(std::string remoteIp, u16 remotePort, u16 localPort)
-{
-	// We are explicitly setting the client address because we are trying to utilize our connection
-	// to the matchmaking service in order to hole punch. This port will end up being the port
-	// we listen on when we start our server
-	ENetAddress clientAddr;
-	clientAddr.host = ENET_HOST_ANY;
-	clientAddr.port = localPort;
-
-	auto client = enet_host_create(&clientAddr, 1, 3, 0, 0);
-
-	if (client == nullptr)
-	{
-		// Failed to create client
-		m_state = ProcessState::ERROR_ENCOUNTERED;
-		m_errorMsg = "Failed to start hole punch";
-		return;
-	}
-
-	ENetAddress addr;
-	enet_address_set_host(&addr, remoteIp.c_str());
-	addr.port = remotePort;
-
-	ERROR_LOG(SLIPPI_ONLINE, "Sending hole punch to: %s:%d", remoteIp.c_str(), remotePort);
-
-	auto server = enet_host_connect(client, &addr, 3, 0);
-
-	if (server == nullptr)
-	{
-		// Failed to connect to server
-		m_state = ProcessState::ERROR_ENCOUNTERED;
-		m_errorMsg = "Failed to start hole punch";
-		return;
-	}
-
-	// Send connect message?
-	enet_host_flush(client);
-
-	enet_peer_reset(server);
-	enet_host_destroy(client);
-}
-
 void SlippiMatchmaking::handleConnecting()
 {
 	std::vector<std::string> ipParts;
 	SplitString(m_oppIp, ':', ipParts);
 
-	sendHolePunchMsg(ipParts[0], std::stoi(ipParts[1]), m_hostPort);
+  // Is host is now used to specify who the decider is
 	auto client = std::make_unique<SlippiNetplayClient>(ipParts[0], std::stoi(ipParts[1]), m_hostPort, m_isHost);
 
 	while (!m_netplayClient)

--- a/Source/Core/Core/Slippi/SlippiNetplay.cpp
+++ b/Source/Core/Core/Slippi/SlippiNetplay.cpp
@@ -103,7 +103,7 @@ SlippiNetplayClient::SlippiNetplayClient(const std::string &address, const u16 r
 	}
 
 	// TODO: Figure out how to use a local port when not hosting without accepting incoming connections
-	m_client = enet_host_create(localAddr, 1, 3, 0, 0);
+	m_client = enet_host_create(localAddr, 2, 3, 0, 0);
 
 	if (m_client == nullptr)
 	{

--- a/Source/Core/Core/Slippi/SlippiNetplay.h
+++ b/Source/Core/Core/Slippi/SlippiNetplay.h
@@ -101,8 +101,8 @@ class SlippiNetplayClient
 	void ThreadFunc();
 	void SendAsync(std::unique_ptr<sf::Packet> packet);
 
-	SlippiNetplayClient(bool isHost); // Make a dummy client
-	SlippiNetplayClient(const std::string &address, const u16 remotePort, const u16 localPort, bool isHost);
+	SlippiNetplayClient(bool isDecider); // Make a dummy client
+	SlippiNetplayClient(const std::string &address, const u16 remotePort, const u16 localPort, bool isDecider);
 	~SlippiNetplayClient();
 
 	// Slippi Online
@@ -115,7 +115,7 @@ class SlippiNetplayClient
 		NET_CONNECT_STATUS_DISCONNECTED,
 	};
 
-	bool IsHost();
+	bool IsDecider();
 	bool IsConnectionSelected();
 	SlippiConnectStatus GetSlippiConnectStatus();
 	void StartSlippiGame();
@@ -169,7 +169,7 @@ class SlippiNetplayClient
 	} frameOffsetData;
 
 	bool isConnectionSelected = false;
-	bool isHost = false;
+	bool isDecider = false;
 	int32_t lastFrameAcked;
 	bool hasGameStarted = false;
 	FrameTiming lastFrameTiming;


### PR DESCRIPTION
Previously when the first host failed and the two players swapped roles, the second host would almost always fail even if they could host. This changes the process to instead try to connect in a bi-directional fashion. It is possible there might be some race conditions doing this so needs some monitoring but hopefully should be better than before.

Additionally when JMC and I tested this with Windows Firewall set to block our Dolphin apps, the connections still went through.