### PR TITLE
Make unicode characters work in Windows default replay folder path

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -763,14 +763,12 @@ std::string GetHomeDirectory()
 #ifdef _WIN32
 	wchar_t *path = nullptr;
 	
-	if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Documents, 0, nullptr, &path))) {
-		char pathStr[MAX_PATH];
-		wcstombs(pathStr, path, MAX_PATH);
-	
-		homeDir = std::string(pathStr);
-		CoTaskMemFree(path);		
+	if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Documents, 0, nullptr, &path)))
+	{
+		homeDir = UTF16ToUTF8(path);
 	}
-	else {
+	else
+	{
 		const char* home = getenv("USERPROFILE");
 		homeDir = std::string(home) + "\\Documents";
 	}


### PR DESCRIPTION
Fixes #90 

I tested this by changing my Documents known folder to one with non-English characters in the path, and the default directory was correctly loaded in Dolphin (i.e. not blank).