### PR TITLE
[PR] Attempt to re-use MM host to connect to opponent

### DIFF
--- a/Source/Core/Common/ENetUtil.cpp
+++ b/Source/Core/Common/ENetUtil.cpp
@@ -49,9 +49,14 @@ DestroyableHost::DestroyableHost(ENetHost *host)
 
 DestroyableHost::~DestroyableHost()
 {
-	enet_host_destroy(host);
-	this->host = nullptr;
-	ERROR_LOG(SLIPPI_ONLINE, "host destroyed");
+	// This if check doesn't seem like it should do anything but idk
+	if (isDestroyed == false)
+	{
+		enet_host_destroy(host);
+		this->host = nullptr;
+		ERROR_LOG(SLIPPI_ONLINE, "host destroyed");
+		isDestroyed = true;
+	}
 }
 
 ENetHost *DestroyableHost::GetHost()

--- a/Source/Core/Common/ENetUtil.cpp
+++ b/Source/Core/Common/ENetUtil.cpp
@@ -4,6 +4,7 @@
 
 #include "ENetUtil.h"
 
+#include "Common/Logging/Log.h"
 #include "Common/CommonTypes.h"
 
 namespace ENetUtil
@@ -41,5 +42,21 @@ int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event)
 	return 0;
 }
 
+DestroyableHost::DestroyableHost(ENetHost *host)
+{
+	this->host = host;
+}
+
+DestroyableHost::~DestroyableHost()
+{
+	enet_host_destroy(host);
+	this->host = nullptr;
+	ERROR_LOG(SLIPPI_ONLINE, "host destroyed");
+}
+
+ENetHost *DestroyableHost::GetHost()
+{
+	return this->host;
+}
 
 }

--- a/Source/Core/Common/ENetUtil.h
+++ b/Source/Core/Common/ENetUtil.h
@@ -9,7 +9,20 @@
 namespace ENetUtil
 {
 
-void WakeupThread(ENetHost* host);
-int ENET_CALLBACK InterceptCallback(ENetHost* host, ENetEvent* event);
+void WakeupThread(ENetHost *host);
+int ENET_CALLBACK InterceptCallback(ENetHost *host, ENetEvent *event);
 
-}
+// Creates a class that can be used with unique_ptr to clean up a host correctly when it's
+// passed between classes
+class DestroyableHost
+{
+  public:
+	DestroyableHost(ENetHost *host);
+	~DestroyableHost();
+	ENetHost *GetHost();
+
+  protected:
+	ENetHost *host;
+};
+
+} // namespace ENetUtil

--- a/Source/Core/Common/ENetUtil.h
+++ b/Source/Core/Common/ENetUtil.h
@@ -22,6 +22,7 @@ class DestroyableHost
 	ENetHost *GetHost();
 
   protected:
+	bool isDestroyed = false;
 	ENetHost *host;
 };
 

--- a/Source/Core/Common/Version.cpp
+++ b/Source/Core/Common/Version.cpp
@@ -23,7 +23,7 @@
 //#else
 //" " BUILD_TYPE_STR " " SCM_DESC_STR;
 //#endif
-#define SLIPPI_REV_STR "2.1.1"
+#define SLIPPI_REV_STR "2.1.2-dev.1"
 const std::string scm_rev_str = "Faster Melee - Slippi (" SLIPPI_REV_STR ")";
 const std::string scm_slippi_semver_str = SLIPPI_REV_STR;
 

--- a/Source/Core/Core/Slippi/SlippiMatchmaking.cpp
+++ b/Source/Core/Core/Slippi/SlippiMatchmaking.cpp
@@ -188,6 +188,9 @@ void SlippiMatchmaking::terminateMmConnection()
 
 void SlippiMatchmaking::startMatchmaking()
 {
+	hostDestroyer.reset();
+	m_client = nullptr;
+
 	int retryCount = 0;
 	while (m_client == nullptr && retryCount < 15)
 	{

--- a/Source/Core/Core/Slippi/SlippiMatchmaking.h
+++ b/Source/Core/Core/Slippi/SlippiMatchmaking.h
@@ -4,6 +4,7 @@
 #include "Common/Thread.h"
 #include "Core/Slippi/SlippiNetplay.h"
 #include "Core/Slippi/SlippiUser.h"
+#include "Common/ENetUtil.h"
 
 #include <enet/enet.h>
 #include <unordered_map>
@@ -54,6 +55,8 @@ class SlippiMatchmaking
 	const u16 MM_PORT = 43113;
 
 	std::string MM_HOST = "";
+
+	std::unique_ptr<ENetUtil::DestroyableHost> hostDestroyer;
 
 	ENetHost *m_client;
 	ENetPeer *m_server;

--- a/Source/Core/Core/Slippi/SlippiNetplay.h
+++ b/Source/Core/Core/Slippi/SlippiNetplay.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+#include "Common/ENetUtil.h"
 #include "Common/Event.h"
 #include "Common/FifoQueue.h"
 #include "Common/Timer.h"
@@ -105,6 +106,8 @@ class SlippiNetplayClient
 
 	SlippiNetplayClient(bool isDecider); // Make a dummy client
 	SlippiNetplayClient(const std::string &address, const u16 remotePort, const u16 localPort, bool isDecider);
+	SlippiNetplayClient(std::unique_ptr<ENetUtil::DestroyableHost> host, const std::string &address,
+	                    const u16 remotePort, bool isDecider);
 	~SlippiNetplayClient();
 
 	// Slippi Online
@@ -143,6 +146,8 @@ class SlippiNetplayClient
 	Common::FifoQueue<std::unique_ptr<sf::Packet>, false> m_async_queue;
 
 	std::string oppName = "";
+
+	std::unique_ptr<ENetUtil::DestroyableHost> hostDestroyer;
 
 	ENetHost *m_client = nullptr;
 	ENetPeer *m_server = nullptr;


### PR DESCRIPTION
This PR is an attempt to make more people capable of hosting. I had a theory before that for some people trying to re-use the same port that was just used to connect to the mm server was either slow or their router would assign a new external port. If these things happened, it might make them unable to host as their opponent would not be sending messages to the port being hole punched.

I was hoping that if I re-used the same exact enet host, I could perhaps ensure that the NAT did not assign a new external port and there was no potential issues with re-using the same port.

I've only tested with one person (who is unable to connect to anyone at all, not just unable to host), and this did not help them. Maybe there are other ideas to try an increase the number of players that can host/connect because this idea may not have worked out. I still intend trying to test with more people though to see if merging this might have some value.