### PR TITLE
Don't allow empty replay directory path

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -601,11 +601,15 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("SlippiSaveReplays", &m_slippiSaveReplays, true);
 	core->Get("SlippiReplayMonthFolders", &m_slippiReplayMonthFolders, false);
 #ifdef _WIN32
-	core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
-		File::GetHomeDirectory() + "\\Slippi");
+	std::string default_replay_dir = File::GetHomeDirectory() + "\\Slippi";
+	core->Get("SlippiReplayDir", &m_strSlippiReplayDir, default_replay_dir);
+	if (m_strSlippiReplayDir.empty())
+		m_strSlippiReplayDir = default_replay_dir;
 #else
-	core->Get("SlippiReplayDir", &m_strSlippiReplayDir,
-		File::GetHomeDirectory() + DIR_SEP + "Slippi");
+	std::string default_replay_dir = File::GetHomeDirectory() + DIR_SEP + "Slippi";
+	core->Get("SlippiReplayDir", &m_strSlippiReplayDir, default_replay_dir);
+	if (m_strSlippiReplayDir.empty())
+		m_strSlippiReplayDir = default_replay_dir;
 #endif
 	core->Get("MemcardAPath", &m_strMemoryCardA);
 	core->Get("MemcardBPath", &m_strMemoryCardB);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -600,17 +600,10 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("SlippiOnlineDelay", &m_slippiOnlineDelay, 2);
 	core->Get("SlippiSaveReplays", &m_slippiSaveReplays, true);
 	core->Get("SlippiReplayMonthFolders", &m_slippiReplayMonthFolders, false);
-#ifdef _WIN32
-	std::string default_replay_dir = File::GetHomeDirectory() + "\\Slippi";
-	core->Get("SlippiReplayDir", &m_strSlippiReplayDir, default_replay_dir);
-	if (m_strSlippiReplayDir.empty())
-		m_strSlippiReplayDir = default_replay_dir;
-#else
 	std::string default_replay_dir = File::GetHomeDirectory() + DIR_SEP + "Slippi";
 	core->Get("SlippiReplayDir", &m_strSlippiReplayDir, default_replay_dir);
 	if (m_strSlippiReplayDir.empty())
 		m_strSlippiReplayDir = default_replay_dir;
-#endif
 	core->Get("MemcardAPath", &m_strMemoryCardA);
 	core->Get("MemcardBPath", &m_strMemoryCardB);
 	core->Get("AgpCartAPath", &m_strGbaCartA);

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -505,6 +505,12 @@ void CEXISlippi::createNewFile()
 	}
 
 	std::string dirpath = SConfig::GetInstance().m_strSlippiReplayDir;
+	// in case the config value just gets lost somehow
+	if (dirpath.empty())
+	{
+		SConfig::GetInstance().m_strSlippiReplayDir = File::GetHomeDirectory() + DIR_SEP + "Slippi";
+		dirpath = SConfig::GetInstance().m_strSlippiReplayDir;
+	}
 
 	// Remove a trailing / or \\ if the user managed to have that in their config
 	char dirpathEnd = dirpath.back();


### PR DESCRIPTION
Empty directory path causes the game to be unplayable at moments. This will always overwrite the directory to the default if the directory string is empty. I considered doing this at the `IniFile.cpp` level, but I wasn't confident it wouldn't mess with some other setting.

Tested on windows by first deleting the value for the replay dir path but leaving the key. Starting dolphin then resulted in the default value appearing.
Secondly, deleted the replay dir in the GUI and then played a game, the value in the GUI did not change (we can't make that happen easily and i believe it is out of the scope of this PR), but the replays saved to the default location.