### PR TITLE
Set sane defaults in Dolphin for Melee/Slippi Online

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -480,7 +480,7 @@ void SConfig::LoadGeneralSettings(IniFile& ini)
 	general->Get("DumpPath", &m_DumpPath);
 	CreateDumpPath(m_DumpPath);
 	general->Get("WirelessMac", &m_WirelessMac);
-	general->Get("WiiSDCardPath", &m_strWiiSDCardPath, File::GetUserPath(F_WIISDCARD_IDX));
+	general->Get("WiiSDCardPath", &m_strWiiSDCardPath);
 	File::SetUserPath(F_WIISDCARD_IDX, m_strWiiSDCardPath);
 }
 
@@ -488,7 +488,7 @@ void SConfig::LoadInterfaceSettings(IniFile& ini)
 {
 	IniFile::Section* interface = ini.GetOrCreateSection("Interface");
 
-	interface->Get("ConfirmStop", &bConfirmStop, true);
+	interface->Get("ConfirmStop", &bConfirmStop, false);
 	interface->Get("UsePanicHandlers", &bUsePanicHandlers, true);
 	interface->Get("OnScreenDisplayMessages", &bOnScreenDisplayMessages, true);
 	interface->Get("HideCursor", &bHideCursor, false);
@@ -590,13 +590,13 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("BootDefaultISO", &bBootDefaultISO, false);
 	core->Get("DVDRoot", &m_strDVDRoot);
 	core->Get("Apploader", &m_strApploader);
-	core->Get("EnableCheats", &bEnableCheats, false);
+	core->Get("EnableCheats", &bEnableCheats, true);
 	core->Get("SelectedLanguage", &SelectedLanguage, 0);
 	core->Get("OverrideGCLang", &bOverrideGCLanguage, false);
 	core->Get("DPL2Decoder", &bDPL2Decoder, false);
 	core->Get("TimeStretching", &bTimeStretching, false);
 	core->Get("RSHACK", &bRSHACK, false);
-	core->Get("Latency", &iLatency, 2);
+	core->Get("Latency", &iLatency, 0);
 	core->Get("SlippiOnlineDelay", &m_slippiOnlineDelay, 2);
 	core->Get("SlippiSaveReplays", &m_slippiSaveReplays, true);
 	core->Get("SlippiReplayMonthFolders", &m_slippiReplayMonthFolders, false);
@@ -681,7 +681,7 @@ void SConfig::LoadDSPSettings(IniFile& ini)
 #elif defined __APPLE__
 	dsp->Get("Backend", &sBackend, BACKEND_COREAUDIO);
 #elif defined _WIN32
-	dsp->Get("Backend", &sBackend, BACKEND_XAUDIO2);
+	dsp->Get("Backend", &sBackend, BACKEND_CUBEB);
 #elif defined ANDROID
 	dsp->Get("Backend", &sBackend, BACKEND_OPENSLES);
 #else

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -97,7 +97,7 @@ NetPlayServer::NetPlayServer(const u16 port, bool traversal, const std::string& 
 		is_connected = true;
 		m_do_loop = true;
 		m_thread = std::thread(&NetPlayServer::ThreadFunc, this);
-		m_minimum_buffer_size = 6;
+		m_minimum_buffer_size = 8;
 	}
 }
 

--- a/Source/Core/DolphinWX/NetPlay/NetWindow.h
+++ b/Source/Core/DolphinWX/NetPlay/NetWindow.h
@@ -43,7 +43,7 @@ enum
 
 enum
 {
-	INITIAL_PAD_BUFFER_SIZE = 6
+	INITIAL_PAD_BUFFER_SIZE = 8
 };
 
 enum class ChatMessageType

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -76,7 +76,7 @@ void VideoConfig::Load(const std::string& ini_file)
 
 	IniFile::Section* settings = iniFile.GetOrCreateSection("Settings");
 	settings->Get("wideScreenHack", &bWidescreenHack, false);
-	settings->Get("AspectRatio", &iAspectRatio, (int)ASPECT_AUTO);
+	settings->Get("AspectRatio", &iAspectRatio, (int)ASPECT_73_60);
 	settings->Get("Crop", &bCrop, false);
 	settings->Get("UseXFB", &bUseXFB, 0);
 	settings->Get("UseRealXFB", &bUseRealXFB, 0);


### PR DESCRIPTION
Open to more suggestions

Enable Cheats: `false` -> `true` (we need cheats on anyways)
Confirm on Stop: `false` -> `true` (based on Overwrite)
Windows Audio Backend: `XAudio2` -> `Cubeb` (based on Overwrite)
Audio Latency: `2` -> `0` (based on Overwrite)
Netplay Min Buffer: `6` -> `8` (to match Slippi Online delay)
Graphics Aspect Ratio: `Auto` -> `73:60` (meleeeeeeeee)