### PR TITLE
[PR] On adapter error, uses previous good inputs

### DIFF
--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
@@ -34,7 +34,7 @@ void AdvancedConfigPane::InitializeGUI()
 	m_clock_override_text = new wxStaticText(this, wxID_ANY, "");
 
 	m_qos_enabled = new wxCheckBox(this, wxID_ANY, _("Enable QoS (Quality of Service) bit on packets"));
-	m_adapter_warning = new wxCheckBox(this, wxID_ANY, _("Neutralize inputs when adapter problems are detected"));
+	m_adapter_warning = new wxCheckBox(this, wxID_ANY, _("Re-use old inputs when adapter problems are detected"));
 	
 	m_custom_rtc_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Custom RTC"));
 	m_custom_rtc_date_picker = new wxDatePickerCtrl(this, wxID_ANY);

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -93,6 +93,7 @@ static void Read()
 		{
 			memcpy(bkp_payload_swap, s_controller_payload_swap, 37);
 			bkp_payload_size = payload_size;
+			has_prev_input = true;
 		}
 		else if (has_prev_input)
 		{

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -85,20 +85,24 @@ static void Read()
 	int payload_size = 0;
 	while (s_adapter_thread_running.IsSet())
 	{
+		bool reuseOldInputsEnabled = SConfig::GetInstance().bAdapterWarning;
 		adapter_error = libusb_interrupt_transfer(s_handle, s_endpoint_in, s_controller_payload_swap,
-			sizeof(s_controller_payload_swap), &payload_size, 16) != LIBUSB_SUCCESS && SConfig::GetInstance().bAdapterWarning;
+			sizeof(s_controller_payload_swap), &payload_size, 16) != LIBUSB_SUCCESS && reuseOldInputsEnabled;
 
 		// Store previous input and restore in the case of an adapter error
-		if (!adapter_error)
+		if (reuseOldInputsEnabled)
 		{
-			memcpy(bkp_payload_swap, s_controller_payload_swap, 37);
-			bkp_payload_size = payload_size;
-			has_prev_input = true;
-		}
-		else if (has_prev_input)
-		{
-			memcpy(s_controller_payload_swap, bkp_payload_swap, 37);
-			payload_size = bkp_payload_size;
+			if (!adapter_error)
+			{
+				memcpy(bkp_payload_swap, s_controller_payload_swap, 37);
+				bkp_payload_size = payload_size;
+				has_prev_input = true;
+			}
+			else if (has_prev_input)
+			{
+				memcpy(s_controller_payload_swap, bkp_payload_swap, 37);
+				payload_size = bkp_payload_size;
+			}
 		}
 
 		{
@@ -424,16 +428,6 @@ GCPadStatus Input(int chan)
 
 	if (s_handle == nullptr || !s_detected)
 		return{};
-
-	if(AdapterError())
-	{
-		GCPadStatus centered_status = {0};
-		centered_status.stickX = centered_status.stickY =
-		centered_status.substickX = centered_status.substickY =
-		/* these are all the same */ GCPadStatus::MAIN_STICK_CENTER_X;
-
-		return centered_status;
-	}
 
 	int payload_size = 0;
 	u8 controller_payload_copy[37];

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -493,7 +493,7 @@ void Renderer::DrawDebugText()
 
 	if(GCAdapter::AdapterError())
 		final_yellow += 
-		"There is a potential problem with your GameCube Adapter and inputs\nare being set to their default positon to prevent unintended inputs"
+		"There is a potential problem with your GameCube Adapter and inputs\nare being set to their previous positon to prevent unintended inputs"
 		"\nIf you want, you can turn this off in [Config] > [Advanced Options]";	
 
 	// and then the text


### PR DESCRIPTION
It's possible doing this is a very bad idea. Trying to check with Dolphin devs before merging. The idea though is that using previous inputs should be a lot less jarring in Melee than neutralizing inputs to zero. That said I couldn't really even find where inputs were being neutralized to zero so this logic might also be in the wrong place.