### PR TITLE
Fix controller adapter detection in macOS 10.13

### DIFF
--- a/Externals/libusb/DOLPHIN
+++ b/Externals/libusb/DOLPHIN
@@ -1,3 +1,11 @@
+Slippi-specific changes (as of 2020-07-05)
+-------------------------------------------
+
+- Updated os/darwin_usb.c to change device claiming, as Apple
+    changed an underlying type between High Sierra and Mojave.
+    When linking against the 10.14SDK, Gamecube Controller Adapters in High Sierra
+    can be properly detected with this.
+
 Dolphin-specific changes (as of 2016-11-20)
 -------------------------------------------
 

--- a/Externals/libusb/libusb/os/darwin_usb.c
+++ b/Externals/libusb/libusb/os/darwin_usb.c
@@ -1325,7 +1325,8 @@ static int darwin_claim_interface(struct libusb_device_handle *dev_handle, int i
 
   /* Do the actual claim */
   kresult = (*plugInInterface)->QueryInterface(plugInInterface,
-                                               CFUUIDGetUUIDBytes(kIOUSBInterfaceInterfaceID),
+                                              CFUUIDGetUUIDBytes(InterfaceInterfaceID),                            
+                                              // CFUUIDGetUUIDBytes(kIOUSBInterfaceInterfaceID),
                                                (LPVOID)&cInterface->interface);
   /* We no longer need the intermediate plug-in */
   /* Use release instead of IODestroyPlugInInterface to avoid stopping IOServices associated with this device */


### PR DESCRIPTION
Rather than link against the 10.13 SDK and lose dark mode, I went looking... and this seemingly works for claiming in libusb with a one line change, [more or less cherrypicking this](https://github.com/libusb/libusb/commit/efa1b280e66c0a62d892bddf826e624362d1e50a).

Testing in Catalina and my adapter is still detected with no apparent issues. Mike4Real tested a build with this in High Sierra; his adapter also detected.

Updated the notes file to explain this oddity as well, in case it ever matters.

Closes #102 