### PR TITLE
Playback: Only generate savestates when seekbar is shown

### DIFF
--- a/Source/Core/Core/Slippi/SlippiPlayback.cpp
+++ b/Source/Core/Core/Slippi/SlippiPlayback.cpp
@@ -235,7 +235,11 @@ void SlippiPlaybackStatus::SeekThread()
 						               &stateString);
 						std::vector<u8> stateToLoad(stateString.begin(), stateString.end());
 						State::LoadFromBuffer(stateToLoad);
-					};
+					}
+					else if (shouldJumpBack)
+					{
+						State::LoadFromBuffer(iState);
+					}
 				}
 			}
 

--- a/Source/Core/Core/Slippi/SlippiPlayback.cpp
+++ b/Source/Core/Core/Slippi/SlippiPlayback.cpp
@@ -192,7 +192,7 @@ void SlippiPlaybackStatus::SeekThread()
 		{
 			auto replayCommSettings = g_replayComm->getSettings();
 			if (replayCommSettings.mode == "queue")
-				clearWatchSettingsStartEnd();
+				updateWatchSettingsStartEnd();
 
 			bool paused = (Core::GetState() == Core::CORE_PAUSE);
 			Core::SetState(Core::CORE_PAUSE);
@@ -269,7 +269,7 @@ void SlippiPlaybackStatus::SeekThread()
 	INFO_LOG(SLIPPI, "Exit seek thread");
 }
 
-void SlippiPlaybackStatus::clearWatchSettingsStartEnd()
+void SlippiPlaybackStatus::updateWatchSettingsStartEnd()
 {
 	int startFrame = g_replayComm->current.startFrame;
 	int endFrame = g_replayComm->current.endFrame;

--- a/Source/Core/Core/Slippi/SlippiPlayback.cpp
+++ b/Source/Core/Core/Slippi/SlippiPlayback.cpp
@@ -164,7 +164,7 @@ void SlippiPlaybackStatus::SavestateThread()
 			processInitialState(iState);
 			inSlippiPlayback = true;
 		}
-		else if (!hasStateBeenProcessed && !isStartFrame)
+		else if (SConfig::GetInstance().m_InterfaceSeekbar && !hasStateBeenProcessed && !isStartFrame)
 		{
 			INFO_LOG(SLIPPI, "saving diff at frame: %d", fixedFrameNumber);
 			State::SaveToBuffer(cState);

--- a/Source/Core/Core/Slippi/SlippiPlayback.cpp
+++ b/Source/Core/Core/Slippi/SlippiPlayback.cpp
@@ -96,8 +96,7 @@ void SlippiPlaybackStatus::prepareSlippiPlayback(s32 &frameIndex)
 
 		if (currentPlaybackFrame > targetFrameNum)
 		{
-			INFO_LOG(SLIPPI, "Reached frame %d. Target was %d. Unblocking", currentPlaybackFrame,
-			         targetFrameNum);
+			INFO_LOG(SLIPPI, "Reached frame %d. Target was %d. Unblocking", currentPlaybackFrame, targetFrameNum);
 		}
 		cv_waitingForTargetFrame.notify_one();
 	}
@@ -235,9 +234,21 @@ void SlippiPlaybackStatus::SeekThread()
 					else if (targetFrameNum < currentPlaybackFrame)
 					{
 						s32 closestActualStateFrame = closestStateFrame - FRAME_INTERVAL;
-						while (closestActualStateFrame > Slippi::PLAYBACK_FIRST_SAVE && futureDiffs.count(closestActualStateFrame) == 0)
+						while (closestActualStateFrame > Slippi::PLAYBACK_FIRST_SAVE &&
+						       futureDiffs.count(closestActualStateFrame) == 0)
 							closestActualStateFrame -= FRAME_INTERVAL;
 						loadState(closestActualStateFrame);
+					}
+					else if (targetFrameNum > currentPlaybackFrame)
+					{
+						s32 closestActualStateFrame = closestStateFrame - FRAME_INTERVAL;
+						while (closestActualStateFrame > currentPlaybackFrame &&
+						       futureDiffs.count(closestActualStateFrame) == 0)
+							closestActualStateFrame -= FRAME_INTERVAL;
+
+						// only load a savestate if we find one past our current frame since we are seeking forwards
+						if (closestActualStateFrame > currentPlaybackFrame)
+							loadState(closestActualStateFrame);
 					}
 				}
 			}

--- a/Source/Core/Core/Slippi/SlippiPlayback.h
+++ b/Source/Core/Core/Slippi/SlippiPlayback.h
@@ -38,7 +38,7 @@ class SlippiPlaybackStatus
 	void SavestateThread(void);
 	void SeekThread(void);
 	void processInitialState(std::vector<u8> &iState);
-	void clearWatchSettingsStartEnd();
+	void updateWatchSettingsStartEnd();
 
 	std::unordered_map<int32_t, std::shared_future<std::string>>
 	    futureDiffs;        // State diffs keyed by frameIndex, processed async

--- a/Source/Core/Core/Slippi/SlippiPlayback.h
+++ b/Source/Core/Core/Slippi/SlippiPlayback.h
@@ -37,6 +37,7 @@ class SlippiPlaybackStatus
   private:
 	void SavestateThread(void);
 	void SeekThread(void);
+	void loadState(s32 closestStateFrame);
 	void processInitialState(std::vector<u8> &iState);
 	void updateWatchSettingsStartEnd();
 


### PR DESCRIPTION
So we've had a user come through asking about why replay playback was worse on their machine after the 1.5.0 Desktop App update. We have deduced the issue to be that their weak computer is unable to generate savestates and emulate at full speed. So I've added a mitigation strategy that should work. This might also help free up some CPU usage when recording/streaming replays/mirrors.

Logic changes:
1. Always generate the first savestate even if the seekbar is hidden, this is to prevent issues if the user decides to show the seekbar later.
2. Only generate savestates if the seekbar is shown.
3. If seeking backwards, load the first available savestate at or before the targetFrameNum (use emod, but if that doesn't point to a savestate then we decrement by 900 until we find a savestate).
4. If seeking forwards, load the first available savestate at or before the targetFrameNum, but after the currentPlaybackFrame (use emod, but if that doesn't point to a savestate then we decrement by 900 until we find a savestate).

I did notice one bug when messing with playback that exists in master, sometimes you need to click twice to seek backwards, i might look into that more before I decide to merge this.