### PR TITLE
Update/inputs

### DIFF
--- a/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/AdvancedConfigPane.cpp
@@ -34,7 +34,7 @@ void AdvancedConfigPane::InitializeGUI()
 	m_clock_override_text = new wxStaticText(this, wxID_ANY, "");
 
 	m_qos_enabled = new wxCheckBox(this, wxID_ANY, _("Enable QoS (Quality of Service) bit on packets"));
-	m_adapter_warning = new wxCheckBox(this, wxID_ANY, _("Re-use old inputs when adapter problems are detected"));
+	m_adapter_warning = new wxCheckBox(this, wxID_ANY, _("Show a message when inputs are being read at a reduced rate"));
 	
 	m_custom_rtc_checkbox = new wxCheckBox(this, wxID_ANY, _("Enable Custom RTC"));
 	m_custom_rtc_date_picker = new wxDatePickerCtrl(this, wxID_ANY);
@@ -49,21 +49,6 @@ void AdvancedConfigPane::InitializeGUI()
 			"can and will break games and cause glitches. "
 			"Do so at your own risk. Please do not report "
 			"bugs that occur with a non-default clock. "));
-
-	/* wxStaticText* const qos_description =
-		new wxStaticText(this, wxID_ANY, _("This setting makes Dolphin tag outgoing packets with a QoS bit.\n\n"
-			"This should make your router prioritize NetPlay packets over normal packets, "
-			"which means you can download and use your Internet connection for other things "
-			"while playing without getting extra packet drops/input lag."
-			"\n\n"
-			"Try turning this setting off if you experience problems with NetPlay."));	
-
-	wxStaticText* const adapter_warning_description =
-		new wxStaticText(this, wxID_ANY, _("This setting makes Dolphin warn and neutralize (centered sticks and no buttons pressed) inputs when an adapter problem is detected.\n\n"
-			"This should only occur when your adapter returns something other than LIBUSB_SUCCESS.\n"
-			"Before turning this off, try reinstalling drivers and switching USB ports."
-			"\n\n"
-			"Try turning this setting off if a false positive error is being detected (though there's a high chance that an actual problem is happening).")); */
 
 	wxStaticText* const custom_rtc_description = new wxStaticText(
 		this, wxID_ANY,

--- a/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.cpp
+++ b/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.cpp
@@ -39,7 +39,7 @@ GCAdapterConfigDiag::GCAdapterConfigDiag(wxWindow* const parent, const wxString&
 	}
 	else
 	{
-		m_adapter_status->SetLabelText(_("Adapter Detected"));
+		m_adapter_status->SetLabelText(wxString::Format("%s (input rate: %.1f hz)", _("Adapter Detected"), 1000.0 / GCAdapter::ReadRate()));
 	}
 	GCAdapter::SetAdapterCallback(std::bind(&GCAdapterConfigDiag::ScheduleAdapterUpdate, this));
 
@@ -47,16 +47,24 @@ GCAdapterConfigDiag::GCAdapterConfigDiag(wxWindow* const parent, const wxString&
 
 	wxBoxSizer* const szr = new wxBoxSizer(wxVERTICAL);
 	szr->Add(m_adapter_status, 0, wxEXPAND);
+	szr->AddSpacer(space5);
 	szr->Add(gamecube_rumble, 0, wxEXPAND);
 	szr->Add(gamecube_konga, 0, wxEXPAND);
 	szr->AddSpacer(space5);
 	szr->Add(CreateButtonSizer(wxCLOSE | wxNO_DEFAULT), 0, wxEXPAND | wxLEFT | wxRIGHT, space5);
 	szr->AddSpacer(space5);
 
-	SetSizerAndFit(szr);
+	wxBoxSizer* const padding_szr = new wxBoxSizer(wxVERTICAL);
+	padding_szr->Add(szr, 0, wxALL, 12);
+
+	SetSizerAndFit(padding_szr);
 	Center();
 
 	Bind(wxEVT_ADAPTER_UPDATE, &GCAdapterConfigDiag::OnUpdateAdapter, this);
+	
+	m_update_rate_timer.SetOwner(this);
+	Bind(wxEVT_TIMER, &GCAdapterConfigDiag::OnUpdateRate, this, m_update_rate_timer.GetId());
+	m_update_rate_timer.Start(1000, wxTIMER_CONTINUOUS);
 }
 
 GCAdapterConfigDiag::~GCAdapterConfigDiag()
@@ -73,7 +81,7 @@ void GCAdapterConfigDiag::OnUpdateAdapter(wxCommandEvent& WXUNUSED(event))
 {
 	bool unpause = Core::PauseAndLock(true);
 	if (GCAdapter::IsDetected())
-		m_adapter_status->SetLabelText(_("Adapter Detected"));
+		m_adapter_status->SetLabelText(wxString::Format("%s (input rate: %.1f hz)", _("Adapter Detected"), 1000.0 / GCAdapter::ReadRate()));
 	else
 		m_adapter_status->SetLabelText(_("Adapter Not Detected"));
 	Core::PauseAndLock(false, unpause);
@@ -87,4 +95,10 @@ void GCAdapterConfigDiag::OnAdapterRumble(wxCommandEvent& event)
 void GCAdapterConfigDiag::OnAdapterKonga(wxCommandEvent& event)
 {
 	SConfig::GetInstance().m_AdapterKonga[m_pad_id] = event.IsChecked();
+}
+
+void GCAdapterConfigDiag::OnUpdateRate(wxTimerEvent& ev) 
+{
+	if (GCAdapter::IsDetected())
+		m_adapter_status->SetLabelText(wxString::Format("%s (input rate: %.1f hz)", _("Adapter Detected"), 1000.0 / GCAdapter::ReadRate()));
 }

--- a/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.h
+++ b/Source/Core/DolphinWX/Config/GCAdapterConfigDiag.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <wx/dialog.h>
+#include <wx/timer.h>
 
 class wxStaticText;
 
@@ -19,8 +20,11 @@ public:
 
 private:
 	wxStaticText* m_adapter_status;
+	wxTimer m_update_rate_timer;
+	
 	int m_pad_id;
 
 	void OnAdapterRumble(wxCommandEvent& event);
 	void OnAdapterKonga(wxCommandEvent& event);
+	void OnUpdateRate(wxTimerEvent& ev);
 };

--- a/Source/Core/DolphinWX/ControllerConfigDiag.cpp
+++ b/Source/Core/DolphinWX/ControllerConfigDiag.cpp
@@ -458,7 +458,7 @@ void ControllerConfigDiag::OnGameCubeConfigButton(wxCommandEvent& event)
 	else if (SConfig::GetInstance().m_SIDevice[port_num] == SIDEVICE_WIIU_ADAPTER)
 	{
 		GCAdapterConfigDiag config_diag(
-			this, wxString::Format(_("Wii U GameCube Controller Adapter Configuration Port %i"),
+			this, wxString::Format(_("Adapter Configuration Port %i"),
 				port_num + 1),
 			port_num);
 		config_diag.ShowModal();

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -6,6 +6,7 @@
 #include <libusb.h>
 #include <mutex>
 #include <iostream>
+#include <chrono>
 
 #include "Common/Event.h"
 #include "Common/Flag.h"
@@ -66,6 +67,8 @@ static u8 s_endpoint_out = 0;
 
 static u64 s_last_init = 0;
 
+static u64 s_consecutive_slow_transfers = 0;
+
 bool adapter_error = false;
 
 bool AdapterError()
@@ -73,8 +76,14 @@ bool AdapterError()
 	return adapter_error && s_adapter_thread_running.IsSet();
 }
 
+bool IsReadingAtReducedRate()
+{
+	return s_consecutive_slow_transfers > 80;
+}
+
 static void Read()
 {
+	s_consecutive_slow_transfers = 0;
 	adapter_error = false;
 
 	u8 bkp_payload_swap[37];
@@ -85,8 +94,11 @@ static void Read()
 	while (s_adapter_thread_running.IsSet())
 	{
 		bool reuseOldInputsEnabled = SConfig::GetInstance().bAdapterWarning;
+		std::chrono::time_point<std::chrono::high_resolution_clock> start = std::chrono::high_resolution_clock::now();
 		adapter_error = libusb_interrupt_transfer(s_handle, s_endpoint_in, s_controller_payload_swap,
-			sizeof(s_controller_payload_swap), &payload_size, 16) != LIBUSB_SUCCESS && reuseOldInputsEnabled;
+			sizeof(s_controller_payload_swap), &payload_size, 32) != LIBUSB_SUCCESS && reuseOldInputsEnabled;
+
+		double elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count() / 1000000.0;
 
 		// Store previous input and restore in the case of an adapter error
 		if (reuseOldInputsEnabled)
@@ -104,6 +116,11 @@ static void Read()
 			}
 		}
 
+		if(elapsed > 15.0)
+			s_consecutive_slow_transfers++;
+		else
+			s_consecutive_slow_transfers = 0;
+		
 		{
 			std::lock_guard<std::mutex> lk(s_mutex);
 			std::swap(s_controller_payload_swap, s_controller_payload);
@@ -123,7 +140,7 @@ static void Write()
 		{
 			unsigned char rumble[5] = {0x11, s_controller_rumble[0], s_controller_rumble[1], s_controller_rumble[2],
 			                           s_controller_rumble[3]};
-			libusb_interrupt_transfer(s_handle, s_endpoint_out, rumble, sizeof(rumble), &size, 16);
+			libusb_interrupt_transfer(s_handle, s_endpoint_out, rumble, sizeof(rumble), &size, 32);
 		}
 	}
 
@@ -364,7 +381,7 @@ static void AddGCAdapter(libusb_device* device)
 
 	int tmp = 0;
 	unsigned char payload = 0x13;
-	libusb_interrupt_transfer(s_handle, s_endpoint_out, &payload, sizeof(payload), &tmp, 16);
+	libusb_interrupt_transfer(s_handle, s_endpoint_out, &payload, sizeof(payload), &tmp, 32);
 
 	s_adapter_thread_running.Set(true);
 	s_adapter_input_thread = std::thread(Read);

--- a/Source/Core/InputCommon/GCAdapter.cpp
+++ b/Source/Core/InputCommon/GCAdapter.cpp
@@ -68,6 +68,7 @@ static u8 s_endpoint_out = 0;
 static u64 s_last_init = 0;
 
 static u64 s_consecutive_slow_transfers = 0;
+static double s_read_rate = 0.0;
 
 bool adapter_error = false;
 
@@ -81,6 +82,11 @@ bool IsReadingAtReducedRate()
 	return s_consecutive_slow_transfers > 80;
 }
 
+double ReadRate() 
+{
+	return s_read_rate;
+}
+
 static void Read()
 {
 	s_consecutive_slow_transfers = 0;
@@ -89,6 +95,7 @@ static void Read()
 	u8 bkp_payload_swap[37];
 	int bkp_payload_size = 0;
 	bool has_prev_input = false;
+	s_read_rate = 0.0;
 
 	int payload_size = 0;
 	while (s_adapter_thread_running.IsSet())
@@ -120,6 +127,8 @@ static void Read()
 			s_consecutive_slow_transfers++;
 		else
 			s_consecutive_slow_transfers = 0;
+
+		s_read_rate = elapsed;
 		
 		{
 			std::lock_guard<std::mutex> lk(s_mutex);

--- a/Source/Core/InputCommon/GCAdapter.h
+++ b/Source/Core/InputCommon/GCAdapter.h
@@ -19,9 +19,7 @@ enum ControllerTypes
 	CONTROLLER_WIRELESS = 2
 };
 
-extern bool adapter_error;
-
-bool AdapterError();
+bool IsReadingAtReducedRate();
 
 void Init();
 void ResetRumble();

--- a/Source/Core/InputCommon/GCAdapter.h
+++ b/Source/Core/InputCommon/GCAdapter.h
@@ -20,6 +20,7 @@ enum ControllerTypes
 };
 
 bool IsReadingAtReducedRate();
+double ReadRate();
 
 void Init();
 void ResetRumble();

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -491,11 +491,24 @@ void Renderer::DrawDebugText()
 	if (g_ActiveConfig.bOverlayProjStats)
 		final_cyan += Statistics::ToStringProj();
 
-	if(GCAdapter::AdapterError())
-		final_yellow += 
-		"There is a potential problem with your GameCube Adapter and inputs\nare being set to their previous positon to prevent unintended inputs"
-		"\nIf you want, you can turn this off in [Config] > [Advanced Options]";	
-
+	if(GCAdapter::IsReadingAtReducedRate() && SConfig::GetInstance().bAdapterWarning)
+	{
+		final_yellow +=
+			"\n"
+			"Your GameCube Controller Adapter is reading inputs at a reduced rate.\n"
+			"You can still play normally but you will experience higher input lag.\n"
+			"This indicates a potential hardware or driver issue.\n"
+			"\n"
+			"If you're using a computer with an AMD Ryzen processor:\n"
+			"Try connecting the black plug of your adapter to a USB 3.0/3.1 Gen 1 port on your motherboard.\n"
+			"These ports are usually blue or say \"SS\" (SuperSpeed). USB 3.2 (light blue) or USB 2.0 (black) will NOT work.\n"
+			"\n"
+			"The recommended driver on Windows is WinUSB. If you're using another driver in Zadig try switching to WinUSB.\n"
+			"\n"
+			"You can turn this message off by going to \"Config\" and then \"Advanced\".\n"
+			"Under \"Troubleshooting\", uncheck \"Show a message when inputs are being read at a reduced rate\".";	
+	}
+	
 	// and then the text
 	RenderText(final_cyan, 20, 20, 0xFF00FFFF);
 	RenderText(final_yellow, 20, 20, 0xFFFFFF00);


### PR DESCRIPTION
Closes #109 

Basically PR 109, but keeps the use previous inputs code.

Text from PR 109

> This[...]increases the timeout for USB interrupt transfers to the adapter. Ryzen users should now be able to play without getting any dropped inputs.

> AMD's USB drivers on Windows poll the adapter every 16 ms instead of every 8 ms (unless certain USB ports are used?). The old timeout of 16 ms meant that some transfers that took slightly too long were dropped completely. We can't solve this issue completely since it's in the driver but a message with troubleshooting help is shown if 80 or more transfers in a row exceed 15 ms. The message can be turned off.

> I also added the current read rate to the adapter configuration dialog for debugging purposes.