### PR TITLE
Disable texture scaling

### DIFF
--- a/Source/Core/DolphinWX/VideoConfigDiag.cpp
+++ b/Source/Core/DolphinWX/VideoConfigDiag.cpp
@@ -503,6 +503,8 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title)
 		wxStaticBoxSizer* const group_enh = new wxStaticBoxSizer(wxVERTICAL, page_enh, _("Enhancements"));
 		group_enh->Add(szr_enh, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 		szr_enh_main->Add(group_enh, 0, wxEXPAND | wxALL, 5);
+		// Feature disabled in Slippi: Texture scaling causes crashes on Pokémon Stadium
+#if ISHIIRUKA_ALLOW_TEXTURE_SCALING
 		{
 			wxFlexGridSizer* const szr_texturescaling = new wxFlexGridSizer(3, 5, 5);
 			szr_texturescaling->AddGrowableCol(1, 1);
@@ -533,6 +535,7 @@ VideoConfigDiag::VideoConfigDiag(wxWindow* parent, const std::string &title)
 			group_scaling->Add(szr_texturescaling, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 			szr_enh_main->Add(group_scaling, 0, wxEXPAND | wxALL, 5);
 		}
+#endif
 		{
 			wxFlexGridSizer* const szr_phong = new wxFlexGridSizer(4, 5, 5);
 			szr_phong->AddGrowableCol(1, 1);

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -742,7 +742,12 @@ TextureCacheBase::TCacheEntryBase* TextureCacheBase::Load(const u32 stage)
 	}
 	// how many levels the allocated texture shall have
 	const u32 texLevels = hires_tex ? hires_tex->m_levels : tex_levels;
+	// Feature disabled in Slippi: Texture scaling causes crashes on Pokémon Stadium
+#if ISHIIRUKA_ALLOW_TEXTURE_SCALING
 	const bool use_scaling = (g_ActiveConfig.iTexScalingType > 0) && !hires_tex && (width < 384) && (height < 384);
+#else
+	const bool use_scaling = false;
+#endif
 	// We can decode on the GPU if it is a supported format and the flag is enabled.
 	// Currently we don't decode RGBA8 textures from Tmem, as that would require copying from both
 	// banks, and if we're doing an copy we may as well just do the whole thing on the CPU, since


### PR DESCRIPTION
It causes crashes on Pokémon Stadium.

As usual, this is untested because I don't have a copy of Melee. What needs testing in particular is enabling texture scaling on an older build and then updating to this build.