### PR TITLE
cmake: Add IS_PLAYBACK definition for macOS/Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,10 @@ option(ENABLE_BLUEZ "Enables bluetooth support" ON)
 #    launch).
 #  * The Dolphin team relies on the data in order to understand the behavior
 #    of our software in the wild.
-option(ENABLE_ANALYTICS "Enables opt-in Analytics collection" ON)
+option(ENABLE_ANALYTICS "Enables opt-in Analytics collection" OFF)
+
+# Playback builds for Slippi include some extra UI tweaks
+option(IS_PLAYBACK "Enable Playback changes" OFF)
 
 # Name of the Dolphin distributor. If you redistribute Dolphin builds (forks,
 # unofficial builds) please consider identifying your distribution with a
@@ -642,6 +645,11 @@ endif()
 if(ENABLE_ANALYTICS)
 	message("Enabling analytics collection (subject to end-user opt-in)")
 	add_definitions(-DUSE_ANALYTICS=1)
+endif()
+
+if(IS_PLAYBACK)
+	message("Enabling Playback changes")
+	add_definitions(-DIS_PLAYBACK)
 endif()
 
 ########################################

--- a/Externals/Bochs_disasm/Bochs_disasm.vcxproj
+++ b/Externals/Bochs_disasm/Bochs_disasm.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/CLRun/clrun/CLRun.vcxproj
+++ b/Externals/CLRun/clrun/CLRun.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/LZO/LZO.vcxproj
+++ b/Externals/LZO/LZO.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/SFML/build/vc2010/SFML_Network.vcxproj
+++ b/Externals/SFML/build/vc2010/SFML_Network.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/SOIL/SOIL.vcxproj
+++ b/Externals/SOIL/SOIL.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/SlippiLib/SlippiLib.vcxproj
+++ b/Externals/SlippiLib/SlippiLib.vcxproj
@@ -13,6 +13,14 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|Win32">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -47,6 +55,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -61,6 +76,13 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -85,6 +107,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -92,6 +117,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|x64'" Label="PropertySheets">
@@ -136,6 +164,21 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -152,6 +195,21 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>

--- a/Externals/cubeb/msvc/cubeb.vcxproj
+++ b/Externals/cubeb/msvc/cubeb.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -30,6 +34,9 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
@@ -46,6 +53,11 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='ReleasePlayback'">
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>

--- a/Externals/curl/curl.vcxproj
+++ b/Externals/curl/curl.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -302,6 +306,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/enet/enet.vcxproj
+++ b/Externals/enet/enet.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -57,6 +61,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/glslang/glslang.vcxproj
+++ b/Externals/glslang/glslang.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -30,6 +34,9 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
@@ -46,6 +53,9 @@
     <ClCompile />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
     <ClCompile />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|x64'">

--- a/Externals/libpng/png/png.vcxproj
+++ b/Externals/libpng/png/png.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/libusb/libusb_static_2013.vcxproj
+++ b/Externals/libusb/libusb_static_2013.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -29,6 +33,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/mbedtls/mbedTLS.vcxproj
+++ b/Externals/mbedtls/mbedTLS.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/miniupnpc/miniupnpc.vcxproj
+++ b/Externals/miniupnpc/miniupnpc.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/nlohmann/nlohmann.vcxproj
+++ b/Externals/nlohmann/nlohmann.vcxproj
@@ -13,6 +13,14 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|Win32">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -46,6 +54,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -60,6 +75,13 @@
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -84,6 +106,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -93,12 +118,28 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
@@ -139,6 +180,19 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>

--- a/Externals/open-vcdiff/open-vcdiff.vcxproj
+++ b/Externals/open-vcdiff/open-vcdiff.vcxproj
@@ -13,6 +13,14 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|Win32">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -89,6 +97,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -103,6 +118,13 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -127,6 +149,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -136,11 +161,17 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|x64'">
@@ -155,10 +186,31 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|Win32'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
@@ -223,6 +275,24 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>

--- a/Externals/semver/semver.vcxproj
+++ b/Externals/semver/semver.vcxproj
@@ -13,6 +13,14 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|Win32">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -48,6 +56,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -62,6 +77,13 @@
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -86,6 +108,9 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -95,12 +120,30 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup />
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>.\include;.\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
@@ -148,6 +191,20 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>

--- a/Externals/soundtouch/SoundTouch.vcxproj
+++ b/Externals/soundtouch/SoundTouch.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/wxWidgets3/build/msw/wx_base.vcxproj
+++ b/Externals/wxWidgets3/build/msw/wx_base.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -1359,6 +1363,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/xbrz/xbrz.vcxproj
+++ b/Externals/xbrz/xbrz.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/xxhash/xxhash.vcxproj
+++ b/Externals/xxhash/xxhash.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Externals/zlib/zlib.vcxproj
+++ b/Externals/zlib/zlib.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Languages/Languages.vcxproj
+++ b/Languages/Languages.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -55,6 +59,11 @@
     <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Utility</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'" Label="Configuration">
     <ConfigurationType>Utility</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>

--- a/Source/Core/AudioCommon/AudioCommon.vcxproj
+++ b/Source/Core/AudioCommon/AudioCommon.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -30,6 +34,9 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
@@ -42,6 +49,11 @@
     <Import Project="..\..\VSProps\PCHUse.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>IS_PLAYBACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="aldlist.cpp" />
     <ClCompile Include="AudioCommon.cpp" />

--- a/Source/Core/Common/Common.vcxproj
+++ b/Source/Core/Common/Common.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -30,6 +34,9 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
@@ -45,6 +52,12 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>IS_PLAYBACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|x64'">

--- a/Source/Core/Common/SCMRevGen.vcxproj
+++ b/Source/Core/Common/SCMRevGen.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -30,6 +34,9 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
@@ -45,6 +52,12 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(ExternalsDir)nlohmann;${ExternalsDir}open-vcdiff;$(ExternalsDir)SlippiLib;$(ExternalsDir)semver;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(ExternalsDir)nlohmann;${ExternalsDir}open-vcdiff;$(ExternalsDir)SlippiLib;$(ExternalsDir)semver;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>IS_PLAYBACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|x64'">

--- a/Source/Core/DiscIO/DiscIO.vcxproj
+++ b/Source/Core/DiscIO/DiscIO.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -30,6 +34,9 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
@@ -42,6 +49,11 @@
     <Import Project="..\..\VSProps\PCHUse.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>IS_PLAYBACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Blob.cpp" />
     <ClCompile Include="CISOBlob.cpp" />

--- a/Source/Core/DolphinWX/Dolphin.vcxproj
+++ b/Source/Core/DolphinWX/Dolphin.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -31,6 +35,9 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
@@ -49,6 +56,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LibraryPath>$(DXSDK_DIR)Lib\x64;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
+    <LibraryPath>$(DXSDK_DIR)Lib\x64;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|x64'">
     <LibraryPath>$(DXSDK_DIR)Lib\x64;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
@@ -61,6 +71,7 @@
       <AdditionalDependencies>avrt.lib;dsound.lib;iphlpapi.lib;winmm.lib;setupapi.lib;OpenAL32.lib;opengl32.lib;glu32.lib;rpcrt4.lib;comctl32.lib;avcodec.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;version.lib;qwave.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/NODEFAULTLIB:libcmt /ignore:4281 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/NODEFAULTLIB:libcmt /ignore:4281 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">/NODEFAULTLIB:libcmt /ignore:4281 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='DebugFast|x64'">/NODEFAULTLIB:libcmt /ignore:4281 %(AdditionalOptions)</AdditionalOptions>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -72,6 +83,9 @@
     <Manifest>
       <EnableDpiAwareness>true</EnableDpiAwareness>
     </Manifest>
+    <ClCompile>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">IS_PLAYBACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AboutDolphin.cpp" />

--- a/Source/Core/DolphinWX/Dolphin.vcxproj.user
+++ b/Source/Core/DolphinWX/Dolphin.vcxproj.user
@@ -10,6 +10,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LocalDebuggerCommandArguments>-d</LocalDebuggerCommandArguments>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
+    <LocalDebuggerCommandArguments>-d</LocalDebuggerCommandArguments>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|x64'">
     <LocalDebuggerCommandArguments>-i "C:/test.json"</LocalDebuggerCommandArguments>
   </PropertyGroup>

--- a/Source/Core/InputCommon/InputCommon.vcxproj
+++ b/Source/Core/InputCommon/InputCommon.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -30,6 +34,9 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
@@ -42,6 +49,11 @@
     <Import Project="..\..\VSProps\PCHUse.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>IS_PLAYBACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="ControllerEmu.cpp" />
     <ClCompile Include="ControllerInterface\ControllerInterface.cpp" />

--- a/Source/Core/UICommon/UICommon.vcxproj
+++ b/Source/Core/UICommon/UICommon.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -30,6 +34,9 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
@@ -42,6 +49,11 @@
     <Import Project="..\..\VSProps\PCHUse.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>IS_PLAYBACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />
   </ItemGroup>

--- a/Source/Core/VideoBackends/D3D12/D3D12.vcxproj
+++ b/Source/Core/VideoBackends/D3D12/D3D12.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -30,6 +34,9 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
@@ -46,6 +53,13 @@
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <ForcedIncludeFiles />
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|x64'">

--- a/Source/Core/VideoBackends/DX11/DX11.vcxproj
+++ b/Source/Core/VideoBackends/DX11/DX11.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -30,6 +34,9 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
@@ -44,6 +51,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugFast|Win32'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />

--- a/Source/Core/VideoBackends/DX9/DX9.vcxproj
+++ b/Source/Core/VideoBackends/DX9/DX9.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -30,6 +34,9 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
@@ -47,6 +54,10 @@
     <LibraryPath>$(LibraryPath);$(DXSDK_DIR)Lib\x64</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>$(IncludePath);$(DXSDK_DIR)Include</IncludePath>
+    <LibraryPath>$(LibraryPath);$(DXSDK_DIR)Lib\x64</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
     <IncludePath>$(IncludePath);$(DXSDK_DIR)Include</IncludePath>
     <LibraryPath>$(LibraryPath);$(DXSDK_DIR)Lib\x64</LibraryPath>
   </PropertyGroup>

--- a/Source/Core/VideoBackends/OGL/OGL.vcxproj
+++ b/Source/Core/VideoBackends/OGL/OGL.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Source/Core/VideoBackends/Software/Software.vcxproj
+++ b/Source/Core/VideoBackends/Software/Software.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Source/Core/VideoBackends/Vulkan/Vulkan.vcxproj
+++ b/Source/Core/VideoBackends/Vulkan/Vulkan.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
@@ -50,6 +57,13 @@
     <Lib />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(ExternalsDir)Vulkan\include;$(ExternalsDir)glslang\glslang\Public;$(ExternalsDir)glslang\SPIRV;$(ExternalsDir)zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Lib />
+    <Lib />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(ExternalsDir)Vulkan\include;$(ExternalsDir)glslang\glslang\Public;$(ExternalsDir)glslang\SPIRV;$(ExternalsDir)zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/Source/Core/VideoCommon/VideoCommon.vcxproj
+++ b/Source/Core/VideoCommon/VideoCommon.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -29,6 +33,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">
@@ -56,6 +63,17 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(ExternalsDir)ffmpeg\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlayback|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(ExternalsDir)ffmpeg\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>IS_PLAYBACK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>

--- a/Source/DSPTool/DSPTool.vcxproj
+++ b/Source/DSPTool/DSPTool.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">

--- a/Source/Dolphin.sln
+++ b/Source/Dolphin.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2002
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30225.117
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Dolphin", "Core\DolphinWX\Dolphin.vcxproj", "{1B099EF8-6F87-47A2-A3E7-898A24584F49}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -172,6 +172,9 @@ Global
 		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
+		ReleasePlayback|Win32 = ReleasePlayback|Win32
+		ReleasePlayback|x64 = ReleasePlayback|x64
+		ReleasePlayback|x86 = ReleasePlayback|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1B099EF8-6F87-47A2-A3E7-898A24584F49}.Debug|Win32.ActiveCfg = Debug|x64
@@ -186,6 +189,10 @@ Global
 		{1B099EF8-6F87-47A2-A3E7-898A24584F49}.Release|x64.ActiveCfg = Release|x64
 		{1B099EF8-6F87-47A2-A3E7-898A24584F49}.Release|x64.Build.0 = Release|x64
 		{1B099EF8-6F87-47A2-A3E7-898A24584F49}.Release|x86.ActiveCfg = Release|x64
+		{1B099EF8-6F87-47A2-A3E7-898A24584F49}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{1B099EF8-6F87-47A2-A3E7-898A24584F49}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{1B099EF8-6F87-47A2-A3E7-898A24584F49}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{1B099EF8-6F87-47A2-A3E7-898A24584F49}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{C87A4178-44F6-49B2-B7AA-C79AF1B8C534}.Debug|Win32.ActiveCfg = Debug|x64
 		{C87A4178-44F6-49B2-B7AA-C79AF1B8C534}.Debug|x64.ActiveCfg = Debug|x64
 		{C87A4178-44F6-49B2-B7AA-C79AF1B8C534}.Debug|x64.Build.0 = Debug|x64
@@ -198,6 +205,10 @@ Global
 		{C87A4178-44F6-49B2-B7AA-C79AF1B8C534}.Release|x64.ActiveCfg = Release|x64
 		{C87A4178-44F6-49B2-B7AA-C79AF1B8C534}.Release|x64.Build.0 = Release|x64
 		{C87A4178-44F6-49B2-B7AA-C79AF1B8C534}.Release|x86.ActiveCfg = Release|x64
+		{C87A4178-44F6-49B2-B7AA-C79AF1B8C534}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{C87A4178-44F6-49B2-B7AA-C79AF1B8C534}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{C87A4178-44F6-49B2-B7AA-C79AF1B8C534}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{C87A4178-44F6-49B2-B7AA-C79AF1B8C534}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{37D007BD-D66C-4EAF-B56C-BD1AAC340A05}.Debug|Win32.ActiveCfg = Debug|x64
 		{37D007BD-D66C-4EAF-B56C-BD1AAC340A05}.Debug|x64.ActiveCfg = Debug|x64
 		{37D007BD-D66C-4EAF-B56C-BD1AAC340A05}.Debug|x64.Build.0 = Debug|x64
@@ -210,6 +221,10 @@ Global
 		{37D007BD-D66C-4EAF-B56C-BD1AAC340A05}.Release|x64.ActiveCfg = Release|x64
 		{37D007BD-D66C-4EAF-B56C-BD1AAC340A05}.Release|x64.Build.0 = Release|x64
 		{37D007BD-D66C-4EAF-B56C-BD1AAC340A05}.Release|x86.ActiveCfg = Release|x64
+		{37D007BD-D66C-4EAF-B56C-BD1AAC340A05}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{37D007BD-D66C-4EAF-B56C-BD1AAC340A05}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{37D007BD-D66C-4EAF-B56C-BD1AAC340A05}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{37D007BD-D66C-4EAF-B56C-BD1AAC340A05}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{677EA016-1182-440C-9345-DC88D1E98C0C}.Debug|Win32.ActiveCfg = Debug|x64
 		{677EA016-1182-440C-9345-DC88D1E98C0C}.Debug|x64.ActiveCfg = Debug|x64
 		{677EA016-1182-440C-9345-DC88D1E98C0C}.Debug|x64.Build.0 = Debug|x64
@@ -222,6 +237,10 @@ Global
 		{677EA016-1182-440C-9345-DC88D1E98C0C}.Release|x64.ActiveCfg = Release|x64
 		{677EA016-1182-440C-9345-DC88D1E98C0C}.Release|x64.Build.0 = Release|x64
 		{677EA016-1182-440C-9345-DC88D1E98C0C}.Release|x86.ActiveCfg = Release|x64
+		{677EA016-1182-440C-9345-DC88D1E98C0C}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{677EA016-1182-440C-9345-DC88D1E98C0C}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{677EA016-1182-440C-9345-DC88D1E98C0C}.ReleasePlayback|x64.Build.0 = Release|x64
+		{677EA016-1182-440C-9345-DC88D1E98C0C}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{93D73454-2512-424E-9CDA-4BB357FE13DD}.Debug|Win32.ActiveCfg = Debug|x64
 		{93D73454-2512-424E-9CDA-4BB357FE13DD}.Debug|x64.ActiveCfg = Debug|x64
 		{93D73454-2512-424E-9CDA-4BB357FE13DD}.Debug|x64.Build.0 = Debug|x64
@@ -234,6 +253,10 @@ Global
 		{93D73454-2512-424E-9CDA-4BB357FE13DD}.Release|x64.ActiveCfg = Release|x64
 		{93D73454-2512-424E-9CDA-4BB357FE13DD}.Release|x64.Build.0 = Release|x64
 		{93D73454-2512-424E-9CDA-4BB357FE13DD}.Release|x86.ActiveCfg = Release|x64
+		{93D73454-2512-424E-9CDA-4BB357FE13DD}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{93D73454-2512-424E-9CDA-4BB357FE13DD}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{93D73454-2512-424E-9CDA-4BB357FE13DD}.ReleasePlayback|x64.Build.0 = Release|x64
+		{93D73454-2512-424E-9CDA-4BB357FE13DD}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{D8890B98-26F7-4CFF-BBFB-B95F371B5F20}.Debug|Win32.ActiveCfg = Debug|x64
 		{D8890B98-26F7-4CFF-BBFB-B95F371B5F20}.Debug|x64.ActiveCfg = Debug|x64
 		{D8890B98-26F7-4CFF-BBFB-B95F371B5F20}.Debug|x64.Build.0 = Debug|x64
@@ -246,6 +269,10 @@ Global
 		{D8890B98-26F7-4CFF-BBFB-B95F371B5F20}.Release|x64.ActiveCfg = Release|x64
 		{D8890B98-26F7-4CFF-BBFB-B95F371B5F20}.Release|x64.Build.0 = Release|x64
 		{D8890B98-26F7-4CFF-BBFB-B95F371B5F20}.Release|x86.ActiveCfg = Release|x64
+		{D8890B98-26F7-4CFF-BBFB-B95F371B5F20}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{D8890B98-26F7-4CFF-BBFB-B95F371B5F20}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{D8890B98-26F7-4CFF-BBFB-B95F371B5F20}.ReleasePlayback|x64.Build.0 = Release|x64
+		{D8890B98-26F7-4CFF-BBFB-B95F371B5F20}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{3E1339F5-9311-4122-9442-369702E8FCAD}.Debug|Win32.ActiveCfg = Debug|x64
 		{3E1339F5-9311-4122-9442-369702E8FCAD}.Debug|x64.ActiveCfg = Debug|x64
 		{3E1339F5-9311-4122-9442-369702E8FCAD}.Debug|x64.Build.0 = Debug|x64
@@ -258,6 +285,10 @@ Global
 		{3E1339F5-9311-4122-9442-369702E8FCAD}.Release|x64.ActiveCfg = Release|x64
 		{3E1339F5-9311-4122-9442-369702E8FCAD}.Release|x64.Build.0 = Release|x64
 		{3E1339F5-9311-4122-9442-369702E8FCAD}.Release|x86.ActiveCfg = Release|x64
+		{3E1339F5-9311-4122-9442-369702E8FCAD}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{3E1339F5-9311-4122-9442-369702E8FCAD}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{3E1339F5-9311-4122-9442-369702E8FCAD}.ReleasePlayback|x64.Build.0 = Release|x64
+		{3E1339F5-9311-4122-9442-369702E8FCAD}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{3E5C4E02-1BA9-4776-BDBE-E3F91FFA34CF}.Debug|Win32.ActiveCfg = Debug|x64
 		{3E5C4E02-1BA9-4776-BDBE-E3F91FFA34CF}.Debug|x64.ActiveCfg = Debug|x64
 		{3E5C4E02-1BA9-4776-BDBE-E3F91FFA34CF}.Debug|x64.Build.0 = Debug|x64
@@ -270,6 +301,10 @@ Global
 		{3E5C4E02-1BA9-4776-BDBE-E3F91FFA34CF}.Release|x64.ActiveCfg = Release|x64
 		{3E5C4E02-1BA9-4776-BDBE-E3F91FFA34CF}.Release|x64.Build.0 = Release|x64
 		{3E5C4E02-1BA9-4776-BDBE-E3F91FFA34CF}.Release|x86.ActiveCfg = Release|x64
+		{3E5C4E02-1BA9-4776-BDBE-E3F91FFA34CF}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{3E5C4E02-1BA9-4776-BDBE-E3F91FFA34CF}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{3E5C4E02-1BA9-4776-BDBE-E3F91FFA34CF}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{3E5C4E02-1BA9-4776-BDBE-E3F91FFA34CF}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{AA862E5E-A993-497A-B6A0-0E8E94B10050}.Debug|Win32.ActiveCfg = Debug|x64
 		{AA862E5E-A993-497A-B6A0-0E8E94B10050}.Debug|x64.ActiveCfg = Debug|x64
 		{AA862E5E-A993-497A-B6A0-0E8E94B10050}.Debug|x64.Build.0 = Debug|x64
@@ -282,6 +317,10 @@ Global
 		{AA862E5E-A993-497A-B6A0-0E8E94B10050}.Release|x64.ActiveCfg = Release|x64
 		{AA862E5E-A993-497A-B6A0-0E8E94B10050}.Release|x64.Build.0 = Release|x64
 		{AA862E5E-A993-497A-B6A0-0E8E94B10050}.Release|x86.ActiveCfg = Release|x64
+		{AA862E5E-A993-497A-B6A0-0E8E94B10050}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{AA862E5E-A993-497A-B6A0-0E8E94B10050}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{AA862E5E-A993-497A-B6A0-0E8E94B10050}.ReleasePlayback|x64.Build.0 = Release|x64
+		{AA862E5E-A993-497A-B6A0-0E8E94B10050}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{8C60E805-0DA5-4E25-8F84-038DB504BB0D}.Debug|Win32.ActiveCfg = Debug|x64
 		{8C60E805-0DA5-4E25-8F84-038DB504BB0D}.Debug|x64.ActiveCfg = Debug|x64
 		{8C60E805-0DA5-4E25-8F84-038DB504BB0D}.Debug|x64.Build.0 = Debug|x64
@@ -294,6 +333,10 @@ Global
 		{8C60E805-0DA5-4E25-8F84-038DB504BB0D}.Release|x64.ActiveCfg = Release|x64
 		{8C60E805-0DA5-4E25-8F84-038DB504BB0D}.Release|x64.Build.0 = Release|x64
 		{8C60E805-0DA5-4E25-8F84-038DB504BB0D}.Release|x86.ActiveCfg = Release|x64
+		{8C60E805-0DA5-4E25-8F84-038DB504BB0D}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{8C60E805-0DA5-4E25-8F84-038DB504BB0D}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{8C60E805-0DA5-4E25-8F84-038DB504BB0D}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{8C60E805-0DA5-4E25-8F84-038DB504BB0D}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{CD3D4C3C-1027-4D33-B047-AEC7B56D0BF6}.Debug|Win32.ActiveCfg = Debug|x64
 		{CD3D4C3C-1027-4D33-B047-AEC7B56D0BF6}.Debug|x64.ActiveCfg = Debug|x64
 		{CD3D4C3C-1027-4D33-B047-AEC7B56D0BF6}.Debug|x64.Build.0 = Debug|x64
@@ -306,6 +349,10 @@ Global
 		{CD3D4C3C-1027-4D33-B047-AEC7B56D0BF6}.Release|x64.ActiveCfg = Release|x64
 		{CD3D4C3C-1027-4D33-B047-AEC7B56D0BF6}.Release|x64.Build.0 = Release|x64
 		{CD3D4C3C-1027-4D33-B047-AEC7B56D0BF6}.Release|x86.ActiveCfg = Release|x64
+		{CD3D4C3C-1027-4D33-B047-AEC7B56D0BF6}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{CD3D4C3C-1027-4D33-B047-AEC7B56D0BF6}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{CD3D4C3C-1027-4D33-B047-AEC7B56D0BF6}.ReleasePlayback|x64.Build.0 = Release|x64
+		{CD3D4C3C-1027-4D33-B047-AEC7B56D0BF6}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{B6398059-EBB6-4C34-B547-95F365B71FF4}.Debug|Win32.ActiveCfg = Debug|x64
 		{B6398059-EBB6-4C34-B547-95F365B71FF4}.Debug|x64.ActiveCfg = Debug|x64
 		{B6398059-EBB6-4C34-B547-95F365B71FF4}.Debug|x64.Build.0 = Debug|x64
@@ -318,6 +365,10 @@ Global
 		{B6398059-EBB6-4C34-B547-95F365B71FF4}.Release|x64.ActiveCfg = Release|x64
 		{B6398059-EBB6-4C34-B547-95F365B71FF4}.Release|x64.Build.0 = Release|x64
 		{B6398059-EBB6-4C34-B547-95F365B71FF4}.Release|x86.ActiveCfg = Release|x64
+		{B6398059-EBB6-4C34-B547-95F365B71FF4}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{B6398059-EBB6-4C34-B547-95F365B71FF4}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{B6398059-EBB6-4C34-B547-95F365B71FF4}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{B6398059-EBB6-4C34-B547-95F365B71FF4}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{DC7D7AF4-CE47-49E8-8B63-265CB6233A49}.Debug|Win32.ActiveCfg = Debug|x64
 		{DC7D7AF4-CE47-49E8-8B63-265CB6233A49}.Debug|x64.ActiveCfg = Debug|x64
 		{DC7D7AF4-CE47-49E8-8B63-265CB6233A49}.Debug|x64.Build.0 = Debug|x64
@@ -330,6 +381,10 @@ Global
 		{DC7D7AF4-CE47-49E8-8B63-265CB6233A49}.Release|x64.ActiveCfg = Release|x64
 		{DC7D7AF4-CE47-49E8-8B63-265CB6233A49}.Release|x64.Build.0 = Release|x64
 		{DC7D7AF4-CE47-49E8-8B63-265CB6233A49}.Release|x86.ActiveCfg = Release|x64
+		{DC7D7AF4-CE47-49E8-8B63-265CB6233A49}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{DC7D7AF4-CE47-49E8-8B63-265CB6233A49}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{DC7D7AF4-CE47-49E8-8B63-265CB6233A49}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{DC7D7AF4-CE47-49E8-8B63-265CB6233A49}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{9A4C733C-BADE-4AC6-B58A-6E274395E90E}.Debug|Win32.ActiveCfg = Debug|x64
 		{9A4C733C-BADE-4AC6-B58A-6E274395E90E}.Debug|x64.ActiveCfg = Debug|x64
 		{9A4C733C-BADE-4AC6-B58A-6E274395E90E}.Debug|x64.Build.0 = Debug|x64
@@ -342,6 +397,10 @@ Global
 		{9A4C733C-BADE-4AC6-B58A-6E274395E90E}.Release|x64.ActiveCfg = Release|x64
 		{9A4C733C-BADE-4AC6-B58A-6E274395E90E}.Release|x64.Build.0 = Release|x64
 		{9A4C733C-BADE-4AC6-B58A-6E274395E90E}.Release|x86.ActiveCfg = Release|x64
+		{9A4C733C-BADE-4AC6-B58A-6E274395E90E}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{9A4C733C-BADE-4AC6-B58A-6E274395E90E}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{9A4C733C-BADE-4AC6-B58A-6E274395E90E}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{9A4C733C-BADE-4AC6-B58A-6E274395E90E}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{1909CD2D-1707-456F-86CA-0DF42A727C99}.Debug|Win32.ActiveCfg = Debug|x64
 		{1909CD2D-1707-456F-86CA-0DF42A727C99}.Debug|x64.ActiveCfg = Debug|x64
 		{1909CD2D-1707-456F-86CA-0DF42A727C99}.Debug|x64.Build.0 = Debug|x64
@@ -354,6 +413,10 @@ Global
 		{1909CD2D-1707-456F-86CA-0DF42A727C99}.Release|x64.ActiveCfg = Release|x64
 		{1909CD2D-1707-456F-86CA-0DF42A727C99}.Release|x64.Build.0 = Release|x64
 		{1909CD2D-1707-456F-86CA-0DF42A727C99}.Release|x86.ActiveCfg = Release|x64
+		{1909CD2D-1707-456F-86CA-0DF42A727C99}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{1909CD2D-1707-456F-86CA-0DF42A727C99}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{1909CD2D-1707-456F-86CA-0DF42A727C99}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{1909CD2D-1707-456F-86CA-0DF42A727C99}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{B39AC394-5DB5-4DA9-9D98-09D46CA3701F}.Debug|Win32.ActiveCfg = Debug|x64
 		{B39AC394-5DB5-4DA9-9D98-09D46CA3701F}.Debug|x64.ActiveCfg = Debug|x64
 		{B39AC394-5DB5-4DA9-9D98-09D46CA3701F}.Debug|x64.Build.0 = Debug|x64
@@ -366,6 +429,10 @@ Global
 		{B39AC394-5DB5-4DA9-9D98-09D46CA3701F}.Release|x64.ActiveCfg = Release|x64
 		{B39AC394-5DB5-4DA9-9D98-09D46CA3701F}.Release|x64.Build.0 = Release|x64
 		{B39AC394-5DB5-4DA9-9D98-09D46CA3701F}.Release|x86.ActiveCfg = Release|x64
+		{B39AC394-5DB5-4DA9-9D98-09D46CA3701F}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{B39AC394-5DB5-4DA9-9D98-09D46CA3701F}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{B39AC394-5DB5-4DA9-9D98-09D46CA3701F}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{B39AC394-5DB5-4DA9-9D98-09D46CA3701F}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{0B8D0A82-C520-46BA-849D-3BB8F637EE0C}.Debug|Win32.ActiveCfg = Debug|x64
 		{0B8D0A82-C520-46BA-849D-3BB8F637EE0C}.Debug|x64.ActiveCfg = Release|x64
 		{0B8D0A82-C520-46BA-849D-3BB8F637EE0C}.Debug|x64.Build.0 = Release|x64
@@ -378,6 +445,10 @@ Global
 		{0B8D0A82-C520-46BA-849D-3BB8F637EE0C}.Release|x64.ActiveCfg = Release|x64
 		{0B8D0A82-C520-46BA-849D-3BB8F637EE0C}.Release|x64.Build.0 = Release|x64
 		{0B8D0A82-C520-46BA-849D-3BB8F637EE0C}.Release|x86.ActiveCfg = Release|x64
+		{0B8D0A82-C520-46BA-849D-3BB8F637EE0C}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{0B8D0A82-C520-46BA-849D-3BB8F637EE0C}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{0B8D0A82-C520-46BA-849D-3BB8F637EE0C}.ReleasePlayback|x64.Build.0 = Release|x64
+		{0B8D0A82-C520-46BA-849D-3BB8F637EE0C}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{1970D175-3DE8-4738-942A-4D98D1CDBF64}.Debug|Win32.ActiveCfg = Debug|x64
 		{1970D175-3DE8-4738-942A-4D98D1CDBF64}.Debug|x64.ActiveCfg = Debug|x64
 		{1970D175-3DE8-4738-942A-4D98D1CDBF64}.Debug|x64.Build.0 = Debug|x64
@@ -390,6 +461,10 @@ Global
 		{1970D175-3DE8-4738-942A-4D98D1CDBF64}.Release|x64.ActiveCfg = Release|x64
 		{1970D175-3DE8-4738-942A-4D98D1CDBF64}.Release|x64.Build.0 = Release|x64
 		{1970D175-3DE8-4738-942A-4D98D1CDBF64}.Release|x86.ActiveCfg = Release|x64
+		{1970D175-3DE8-4738-942A-4D98D1CDBF64}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{1970D175-3DE8-4738-942A-4D98D1CDBF64}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{1970D175-3DE8-4738-942A-4D98D1CDBF64}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{1970D175-3DE8-4738-942A-4D98D1CDBF64}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{1C8436C9-DBAF-42BE-83BC-CF3EC9175ABE}.Debug|Win32.ActiveCfg = Debug|x64
 		{1C8436C9-DBAF-42BE-83BC-CF3EC9175ABE}.Debug|x64.ActiveCfg = Debug|x64
 		{1C8436C9-DBAF-42BE-83BC-CF3EC9175ABE}.Debug|x64.Build.0 = Debug|x64
@@ -402,6 +477,10 @@ Global
 		{1C8436C9-DBAF-42BE-83BC-CF3EC9175ABE}.Release|x64.ActiveCfg = Release|x64
 		{1C8436C9-DBAF-42BE-83BC-CF3EC9175ABE}.Release|x64.Build.0 = Release|x64
 		{1C8436C9-DBAF-42BE-83BC-CF3EC9175ABE}.Release|x86.ActiveCfg = Release|x64
+		{1C8436C9-DBAF-42BE-83BC-CF3EC9175ABE}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{1C8436C9-DBAF-42BE-83BC-CF3EC9175ABE}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{1C8436C9-DBAF-42BE-83BC-CF3EC9175ABE}.ReleasePlayback|x64.Build.0 = Release|x64
+		{1C8436C9-DBAF-42BE-83BC-CF3EC9175ABE}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{01573C36-AC6E-49F6-94BA-572517EB9740}.Debug|Win32.ActiveCfg = Debug|x64
 		{01573C36-AC6E-49F6-94BA-572517EB9740}.Debug|x64.ActiveCfg = Debug|x64
 		{01573C36-AC6E-49F6-94BA-572517EB9740}.Debug|x64.Build.0 = Debug|x64
@@ -414,6 +493,10 @@ Global
 		{01573C36-AC6E-49F6-94BA-572517EB9740}.Release|x64.ActiveCfg = Release|x64
 		{01573C36-AC6E-49F6-94BA-572517EB9740}.Release|x64.Build.0 = Release|x64
 		{01573C36-AC6E-49F6-94BA-572517EB9740}.Release|x86.ActiveCfg = Release|x64
+		{01573C36-AC6E-49F6-94BA-572517EB9740}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{01573C36-AC6E-49F6-94BA-572517EB9740}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{01573C36-AC6E-49F6-94BA-572517EB9740}.ReleasePlayback|x64.Build.0 = Release|x64
+		{01573C36-AC6E-49F6-94BA-572517EB9740}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{69F00340-5C3D-449F-9A80-958435C6CF06}.Debug|Win32.ActiveCfg = Debug|x64
 		{69F00340-5C3D-449F-9A80-958435C6CF06}.Debug|x64.ActiveCfg = Release|x64
 		{69F00340-5C3D-449F-9A80-958435C6CF06}.Debug|x64.Build.0 = Release|x64
@@ -426,6 +509,10 @@ Global
 		{69F00340-5C3D-449F-9A80-958435C6CF06}.Release|x64.ActiveCfg = Release|x64
 		{69F00340-5C3D-449F-9A80-958435C6CF06}.Release|x64.Build.0 = Release|x64
 		{69F00340-5C3D-449F-9A80-958435C6CF06}.Release|x86.ActiveCfg = Release|x64
+		{69F00340-5C3D-449F-9A80-958435C6CF06}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{69F00340-5C3D-449F-9A80-958435C6CF06}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{69F00340-5C3D-449F-9A80-958435C6CF06}.ReleasePlayback|x64.Build.0 = Release|x64
+		{69F00340-5C3D-449F-9A80-958435C6CF06}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{68A5DD20-7057-448B-8FE0-B6AC8D205509}.Debug|Win32.ActiveCfg = Debug|x64
 		{68A5DD20-7057-448B-8FE0-B6AC8D205509}.Debug|x64.ActiveCfg = Debug|x64
 		{68A5DD20-7057-448B-8FE0-B6AC8D205509}.Debug|x64.Build.0 = Debug|x64
@@ -438,6 +525,10 @@ Global
 		{68A5DD20-7057-448B-8FE0-B6AC8D205509}.Release|x64.ActiveCfg = Release|x64
 		{68A5DD20-7057-448B-8FE0-B6AC8D205509}.Release|x64.Build.0 = Release|x64
 		{68A5DD20-7057-448B-8FE0-B6AC8D205509}.Release|x86.ActiveCfg = Release|x64
+		{68A5DD20-7057-448B-8FE0-B6AC8D205509}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{68A5DD20-7057-448B-8FE0-B6AC8D205509}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{68A5DD20-7057-448B-8FE0-B6AC8D205509}.ReleasePlayback|x64.Build.0 = Release|x64
+		{68A5DD20-7057-448B-8FE0-B6AC8D205509}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{46CF2D25-6A36-4189-B59C-E4815388E554}.Debug|Win32.ActiveCfg = Debug|x64
 		{46CF2D25-6A36-4189-B59C-E4815388E554}.Debug|x64.ActiveCfg = Debug|x64
 		{46CF2D25-6A36-4189-B59C-E4815388E554}.Debug|x64.Build.0 = Debug|x64
@@ -450,6 +541,10 @@ Global
 		{46CF2D25-6A36-4189-B59C-E4815388E554}.Release|x64.ActiveCfg = Release|x64
 		{46CF2D25-6A36-4189-B59C-E4815388E554}.Release|x64.Build.0 = Release|x64
 		{46CF2D25-6A36-4189-B59C-E4815388E554}.Release|x86.ActiveCfg = Release|x64
+		{46CF2D25-6A36-4189-B59C-E4815388E554}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{46CF2D25-6A36-4189-B59C-E4815388E554}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{46CF2D25-6A36-4189-B59C-E4815388E554}.ReleasePlayback|x64.Build.0 = Release|x64
+		{46CF2D25-6A36-4189-B59C-E4815388E554}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{A680190D-0764-485B-9CF3-A82C5EDD5715}.Debug|Win32.ActiveCfg = Debug|x64
 		{A680190D-0764-485B-9CF3-A82C5EDD5715}.Debug|x64.ActiveCfg = Debug|x64
 		{A680190D-0764-485B-9CF3-A82C5EDD5715}.Debug|x64.Build.0 = Debug|x64
@@ -462,6 +557,10 @@ Global
 		{A680190D-0764-485B-9CF3-A82C5EDD5715}.Release|x64.ActiveCfg = Release|x64
 		{A680190D-0764-485B-9CF3-A82C5EDD5715}.Release|x64.Build.0 = Release|x64
 		{A680190D-0764-485B-9CF3-A82C5EDD5715}.Release|x86.ActiveCfg = Release|x64
+		{A680190D-0764-485B-9CF3-A82C5EDD5715}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{A680190D-0764-485B-9CF3-A82C5EDD5715}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{A680190D-0764-485B-9CF3-A82C5EDD5715}.ReleasePlayback|x64.Build.0 = Release|x64
+		{A680190D-0764-485B-9CF3-A82C5EDD5715}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{349EE8F9-7D25-4909-AAF5-FF3FADE72187}.Debug|Win32.ActiveCfg = Debug|x64
 		{349EE8F9-7D25-4909-AAF5-FF3FADE72187}.Debug|x64.ActiveCfg = Debug|x64
 		{349EE8F9-7D25-4909-AAF5-FF3FADE72187}.Debug|x64.Build.0 = Debug|x64
@@ -474,6 +573,10 @@ Global
 		{349EE8F9-7D25-4909-AAF5-FF3FADE72187}.Release|x64.ActiveCfg = Release|x64
 		{349EE8F9-7D25-4909-AAF5-FF3FADE72187}.Release|x64.Build.0 = Release|x64
 		{349EE8F9-7D25-4909-AAF5-FF3FADE72187}.Release|x86.ActiveCfg = Release|x64
+		{349EE8F9-7D25-4909-AAF5-FF3FADE72187}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{349EE8F9-7D25-4909-AAF5-FF3FADE72187}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{349EE8F9-7D25-4909-AAF5-FF3FADE72187}.ReleasePlayback|x64.Build.0 = Release|x64
+		{349EE8F9-7D25-4909-AAF5-FF3FADE72187}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{76563A7F-1011-4EAD-B667-7BB18D09568E}.Debug|Win32.ActiveCfg = Debug|x64
 		{76563A7F-1011-4EAD-B667-7BB18D09568E}.Debug|x64.ActiveCfg = Debug|x64
 		{76563A7F-1011-4EAD-B667-7BB18D09568E}.Debug|x64.Build.0 = Debug|x64
@@ -486,6 +589,10 @@ Global
 		{76563A7F-1011-4EAD-B667-7BB18D09568E}.Release|x64.ActiveCfg = Release|x64
 		{76563A7F-1011-4EAD-B667-7BB18D09568E}.Release|x64.Build.0 = Release|x64
 		{76563A7F-1011-4EAD-B667-7BB18D09568E}.Release|x86.ActiveCfg = Release|x64
+		{76563A7F-1011-4EAD-B667-7BB18D09568E}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{76563A7F-1011-4EAD-B667-7BB18D09568E}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{76563A7F-1011-4EAD-B667-7BB18D09568E}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{76563A7F-1011-4EAD-B667-7BB18D09568E}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{604C8368-F34A-4D55-82C8-CC92A0C13254}.Debug|Win32.ActiveCfg = Debug|x64
 		{604C8368-F34A-4D55-82C8-CC92A0C13254}.Debug|x64.ActiveCfg = Debug|x64
 		{604C8368-F34A-4D55-82C8-CC92A0C13254}.Debug|x64.Build.0 = Debug|x64
@@ -498,6 +605,10 @@ Global
 		{604C8368-F34A-4D55-82C8-CC92A0C13254}.Release|x64.ActiveCfg = Release|x64
 		{604C8368-F34A-4D55-82C8-CC92A0C13254}.Release|x64.Build.0 = Release|x64
 		{604C8368-F34A-4D55-82C8-CC92A0C13254}.Release|x86.ActiveCfg = Release|x64
+		{604C8368-F34A-4D55-82C8-CC92A0C13254}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{604C8368-F34A-4D55-82C8-CC92A0C13254}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{604C8368-F34A-4D55-82C8-CC92A0C13254}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{604C8368-F34A-4D55-82C8-CC92A0C13254}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{CBC76802-C128-4B17-BF6C-23B08C313E5E}.Debug|Win32.ActiveCfg = Debug|x64
 		{CBC76802-C128-4B17-BF6C-23B08C313E5E}.Debug|x64.ActiveCfg = Debug|x64
 		{CBC76802-C128-4B17-BF6C-23B08C313E5E}.Debug|x64.Build.0 = Debug|x64
@@ -510,6 +621,10 @@ Global
 		{CBC76802-C128-4B17-BF6C-23B08C313E5E}.Release|x64.ActiveCfg = Release|x64
 		{CBC76802-C128-4B17-BF6C-23B08C313E5E}.Release|x64.Build.0 = Release|x64
 		{CBC76802-C128-4B17-BF6C-23B08C313E5E}.Release|x86.ActiveCfg = Release|x64
+		{CBC76802-C128-4B17-BF6C-23B08C313E5E}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{CBC76802-C128-4B17-BF6C-23B08C313E5E}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{CBC76802-C128-4B17-BF6C-23B08C313E5E}.ReleasePlayback|x64.Build.0 = Release|x64
+		{CBC76802-C128-4B17-BF6C-23B08C313E5E}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{BB00605C-125F-4A21-B33B-7BF418322DCB}.Debug|Win32.ActiveCfg = Debug|x64
 		{BB00605C-125F-4A21-B33B-7BF418322DCB}.Debug|x64.ActiveCfg = Debug|x64
 		{BB00605C-125F-4A21-B33B-7BF418322DCB}.Debug|x64.Build.0 = Debug|x64
@@ -522,6 +637,10 @@ Global
 		{BB00605C-125F-4A21-B33B-7BF418322DCB}.Release|x64.ActiveCfg = Release|x64
 		{BB00605C-125F-4A21-B33B-7BF418322DCB}.Release|x64.Build.0 = Release|x64
 		{BB00605C-125F-4A21-B33B-7BF418322DCB}.Release|x86.ActiveCfg = Release|x64
+		{BB00605C-125F-4A21-B33B-7BF418322DCB}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{BB00605C-125F-4A21-B33B-7BF418322DCB}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{BB00605C-125F-4A21-B33B-7BF418322DCB}.ReleasePlayback|x64.Build.0 = Release|x64
+		{BB00605C-125F-4A21-B33B-7BF418322DCB}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{869EA016-4458-2A45-25AF-DC44D6E98C0A}.Debug|Win32.ActiveCfg = Debug|x64
 		{869EA016-4458-2A45-25AF-DC44D6E98C0A}.Debug|x64.ActiveCfg = Debug|x64
 		{869EA016-4458-2A45-25AF-DC44D6E98C0A}.Debug|x64.Build.0 = Debug|x64
@@ -534,6 +653,10 @@ Global
 		{869EA016-4458-2A45-25AF-DC44D6E98C0A}.Release|x64.ActiveCfg = Release|x64
 		{869EA016-4458-2A45-25AF-DC44D6E98C0A}.Release|x64.Build.0 = Release|x64
 		{869EA016-4458-2A45-25AF-DC44D6E98C0A}.Release|x86.ActiveCfg = Release|x64
+		{869EA016-4458-2A45-25AF-DC44D6E98C0A}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{869EA016-4458-2A45-25AF-DC44D6E98C0A}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{869EA016-4458-2A45-25AF-DC44D6E98C0A}.ReleasePlayback|x64.Build.0 = Release|x64
+		{869EA016-4458-2A45-25AF-DC44D6E98C0A}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{570215B7-E32F-4438-95AE-C8D955F9FCA3}.Debug|Win32.ActiveCfg = Debug|x64
 		{570215B7-E32F-4438-95AE-C8D955F9FCA3}.Debug|x64.ActiveCfg = Debug|x64
 		{570215B7-E32F-4438-95AE-C8D955F9FCA3}.Debug|x64.Build.0 = Debug|x64
@@ -546,6 +669,10 @@ Global
 		{570215B7-E32F-4438-95AE-C8D955F9FCA3}.Release|x64.ActiveCfg = Release|x64
 		{570215B7-E32F-4438-95AE-C8D955F9FCA3}.Release|x64.Build.0 = Release|x64
 		{570215B7-E32F-4438-95AE-C8D955F9FCA3}.Release|x86.ActiveCfg = Release|x64
+		{570215B7-E32F-4438-95AE-C8D955F9FCA3}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{570215B7-E32F-4438-95AE-C8D955F9FCA3}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{570215B7-E32F-4438-95AE-C8D955F9FCA3}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{570215B7-E32F-4438-95AE-C8D955F9FCA3}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{B441CC62-877E-4B3F-93E0-0DE80544F705}.Debug|Win32.ActiveCfg = Debug|x64
 		{B441CC62-877E-4B3F-93E0-0DE80544F705}.Debug|x64.ActiveCfg = Debug|x64
 		{B441CC62-877E-4B3F-93E0-0DE80544F705}.Debug|x64.Build.0 = Debug|x64
@@ -558,6 +685,10 @@ Global
 		{B441CC62-877E-4B3F-93E0-0DE80544F705}.Release|x64.ActiveCfg = Release|x64
 		{B441CC62-877E-4B3F-93E0-0DE80544F705}.Release|x64.Build.0 = Release|x64
 		{B441CC62-877E-4B3F-93E0-0DE80544F705}.Release|x86.ActiveCfg = Release|x64
+		{B441CC62-877E-4B3F-93E0-0DE80544F705}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{B441CC62-877E-4B3F-93E0-0DE80544F705}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{B441CC62-877E-4B3F-93E0-0DE80544F705}.ReleasePlayback|x64.Build.0 = Release|x64
+		{B441CC62-877E-4B3F-93E0-0DE80544F705}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{9E9DA440-E9AD-413C-B648-91030E792211}.Debug|Win32.ActiveCfg = Debug|x64
 		{9E9DA440-E9AD-413C-B648-91030E792211}.Debug|x64.ActiveCfg = Debug|x64
 		{9E9DA440-E9AD-413C-B648-91030E792211}.Debug|x64.Build.0 = Debug|x64
@@ -570,6 +701,10 @@ Global
 		{9E9DA440-E9AD-413C-B648-91030E792211}.Release|x64.ActiveCfg = Release|x64
 		{9E9DA440-E9AD-413C-B648-91030E792211}.Release|x64.Build.0 = Release|x64
 		{9E9DA440-E9AD-413C-B648-91030E792211}.Release|x86.ActiveCfg = Release|x64
+		{9E9DA440-E9AD-413C-B648-91030E792211}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{9E9DA440-E9AD-413C-B648-91030E792211}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{9E9DA440-E9AD-413C-B648-91030E792211}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{9E9DA440-E9AD-413C-B648-91030E792211}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{D178061B-84D3-44F9-BEED-EFD18D9033F0}.Debug|Win32.ActiveCfg = Debug|x64
 		{D178061B-84D3-44F9-BEED-EFD18D9033F0}.Debug|x64.ActiveCfg = Debug|x64
 		{D178061B-84D3-44F9-BEED-EFD18D9033F0}.Debug|x64.Build.0 = Debug|x64
@@ -582,6 +717,10 @@ Global
 		{D178061B-84D3-44F9-BEED-EFD18D9033F0}.Release|x64.ActiveCfg = Release|x64
 		{D178061B-84D3-44F9-BEED-EFD18D9033F0}.Release|x64.Build.0 = Release|x64
 		{D178061B-84D3-44F9-BEED-EFD18D9033F0}.Release|x86.ActiveCfg = Release|x64
+		{D178061B-84D3-44F9-BEED-EFD18D9033F0}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{D178061B-84D3-44F9-BEED-EFD18D9033F0}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{D178061B-84D3-44F9-BEED-EFD18D9033F0}.ReleasePlayback|x64.Build.0 = Release|x64
+		{D178061B-84D3-44F9-BEED-EFD18D9033F0}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{29F29A19-F141-45AD-9679-5A2923B49DA3}.Debug|Win32.ActiveCfg = Debug|x64
 		{29F29A19-F141-45AD-9679-5A2923B49DA3}.Debug|x64.ActiveCfg = Debug|x64
 		{29F29A19-F141-45AD-9679-5A2923B49DA3}.Debug|x64.Build.0 = Debug|x64
@@ -594,6 +733,10 @@ Global
 		{29F29A19-F141-45AD-9679-5A2923B49DA3}.Release|x64.ActiveCfg = Release|x64
 		{29F29A19-F141-45AD-9679-5A2923B49DA3}.Release|x64.Build.0 = Release|x64
 		{29F29A19-F141-45AD-9679-5A2923B49DA3}.Release|x86.ActiveCfg = Release|x64
+		{29F29A19-F141-45AD-9679-5A2923B49DA3}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{29F29A19-F141-45AD-9679-5A2923B49DA3}.ReleasePlayback|x64.ActiveCfg = ReleasePlayback|x64
+		{29F29A19-F141-45AD-9679-5A2923B49DA3}.ReleasePlayback|x64.Build.0 = ReleasePlayback|x64
+		{29F29A19-F141-45AD-9679-5A2923B49DA3}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{FF39260B-839A-4A6C-A117-CAA73C1683F5}.Debug|Win32.ActiveCfg = Debug|Win32
 		{FF39260B-839A-4A6C-A117-CAA73C1683F5}.Debug|Win32.Build.0 = Debug|Win32
 		{FF39260B-839A-4A6C-A117-CAA73C1683F5}.Debug|x64.ActiveCfg = Debug|x64
@@ -612,6 +755,12 @@ Global
 		{FF39260B-839A-4A6C-A117-CAA73C1683F5}.Release|x64.Build.0 = Release|x64
 		{FF39260B-839A-4A6C-A117-CAA73C1683F5}.Release|x86.ActiveCfg = Release|Win32
 		{FF39260B-839A-4A6C-A117-CAA73C1683F5}.Release|x86.Build.0 = Release|Win32
+		{FF39260B-839A-4A6C-A117-CAA73C1683F5}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|Win32
+		{FF39260B-839A-4A6C-A117-CAA73C1683F5}.ReleasePlayback|Win32.Build.0 = ReleasePlayback|Win32
+		{FF39260B-839A-4A6C-A117-CAA73C1683F5}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{FF39260B-839A-4A6C-A117-CAA73C1683F5}.ReleasePlayback|x64.Build.0 = Release|x64
+		{FF39260B-839A-4A6C-A117-CAA73C1683F5}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|Win32
+		{FF39260B-839A-4A6C-A117-CAA73C1683F5}.ReleasePlayback|x86.Build.0 = ReleasePlayback|Win32
 		{8EA11166-6512-44FC-B7A5-A4D1ECC81170}.Debug|Win32.ActiveCfg = Debug|x64
 		{8EA11166-6512-44FC-B7A5-A4D1ECC81170}.Debug|x64.ActiveCfg = Debug|x64
 		{8EA11166-6512-44FC-B7A5-A4D1ECC81170}.Debug|x64.Build.0 = Debug|x64
@@ -624,6 +773,10 @@ Global
 		{8EA11166-6512-44FC-B7A5-A4D1ECC81170}.Release|x64.ActiveCfg = Release|x64
 		{8EA11166-6512-44FC-B7A5-A4D1ECC81170}.Release|x64.Build.0 = Release|x64
 		{8EA11166-6512-44FC-B7A5-A4D1ECC81170}.Release|x86.ActiveCfg = Release|x64
+		{8EA11166-6512-44FC-B7A5-A4D1ECC81170}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|x64
+		{8EA11166-6512-44FC-B7A5-A4D1ECC81170}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{8EA11166-6512-44FC-B7A5-A4D1ECC81170}.ReleasePlayback|x64.Build.0 = Release|x64
+		{8EA11166-6512-44FC-B7A5-A4D1ECC81170}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|x64
 		{732D2110-06A3-4AA1-9634-7BB5A4F75B82}.Debug|Win32.ActiveCfg = Debug|Win32
 		{732D2110-06A3-4AA1-9634-7BB5A4F75B82}.Debug|Win32.Build.0 = Debug|Win32
 		{732D2110-06A3-4AA1-9634-7BB5A4F75B82}.Debug|x64.ActiveCfg = Debug|x64
@@ -642,6 +795,12 @@ Global
 		{732D2110-06A3-4AA1-9634-7BB5A4F75B82}.Release|x64.Build.0 = Release|x64
 		{732D2110-06A3-4AA1-9634-7BB5A4F75B82}.Release|x86.ActiveCfg = Release|Win32
 		{732D2110-06A3-4AA1-9634-7BB5A4F75B82}.Release|x86.Build.0 = Release|Win32
+		{732D2110-06A3-4AA1-9634-7BB5A4F75B82}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|Win32
+		{732D2110-06A3-4AA1-9634-7BB5A4F75B82}.ReleasePlayback|Win32.Build.0 = ReleasePlayback|Win32
+		{732D2110-06A3-4AA1-9634-7BB5A4F75B82}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{732D2110-06A3-4AA1-9634-7BB5A4F75B82}.ReleasePlayback|x64.Build.0 = Release|x64
+		{732D2110-06A3-4AA1-9634-7BB5A4F75B82}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|Win32
+		{732D2110-06A3-4AA1-9634-7BB5A4F75B82}.ReleasePlayback|x86.Build.0 = ReleasePlayback|Win32
 		{9193A8DE-BC2E-458C-B52E-510457EEE4B8}.Debug|Win32.ActiveCfg = Debug|Win32
 		{9193A8DE-BC2E-458C-B52E-510457EEE4B8}.Debug|Win32.Build.0 = Debug|Win32
 		{9193A8DE-BC2E-458C-B52E-510457EEE4B8}.Debug|x64.ActiveCfg = Debug|x64
@@ -660,6 +819,12 @@ Global
 		{9193A8DE-BC2E-458C-B52E-510457EEE4B8}.Release|x64.Build.0 = Release|x64
 		{9193A8DE-BC2E-458C-B52E-510457EEE4B8}.Release|x86.ActiveCfg = Release|Win32
 		{9193A8DE-BC2E-458C-B52E-510457EEE4B8}.Release|x86.Build.0 = Release|Win32
+		{9193A8DE-BC2E-458C-B52E-510457EEE4B8}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|Win32
+		{9193A8DE-BC2E-458C-B52E-510457EEE4B8}.ReleasePlayback|Win32.Build.0 = ReleasePlayback|Win32
+		{9193A8DE-BC2E-458C-B52E-510457EEE4B8}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{9193A8DE-BC2E-458C-B52E-510457EEE4B8}.ReleasePlayback|x64.Build.0 = Release|x64
+		{9193A8DE-BC2E-458C-B52E-510457EEE4B8}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|Win32
+		{9193A8DE-BC2E-458C-B52E-510457EEE4B8}.ReleasePlayback|x86.Build.0 = ReleasePlayback|Win32
 		{1BC426C4-AF38-4C29-A925-02406BC00490}.Debug|Win32.ActiveCfg = Debug|Win32
 		{1BC426C4-AF38-4C29-A925-02406BC00490}.Debug|Win32.Build.0 = Debug|Win32
 		{1BC426C4-AF38-4C29-A925-02406BC00490}.Debug|x64.ActiveCfg = Debug|x64
@@ -678,6 +843,12 @@ Global
 		{1BC426C4-AF38-4C29-A925-02406BC00490}.Release|x64.Build.0 = Release|x64
 		{1BC426C4-AF38-4C29-A925-02406BC00490}.Release|x86.ActiveCfg = Release|Win32
 		{1BC426C4-AF38-4C29-A925-02406BC00490}.Release|x86.Build.0 = Release|Win32
+		{1BC426C4-AF38-4C29-A925-02406BC00490}.ReleasePlayback|Win32.ActiveCfg = ReleasePlayback|Win32
+		{1BC426C4-AF38-4C29-A925-02406BC00490}.ReleasePlayback|Win32.Build.0 = ReleasePlayback|Win32
+		{1BC426C4-AF38-4C29-A925-02406BC00490}.ReleasePlayback|x64.ActiveCfg = Release|x64
+		{1BC426C4-AF38-4C29-A925-02406BC00490}.ReleasePlayback|x64.Build.0 = Release|x64
+		{1BC426C4-AF38-4C29-A925-02406BC00490}.ReleasePlayback|x86.ActiveCfg = ReleasePlayback|Win32
+		{1BC426C4-AF38-4C29-A925-02406BC00490}.ReleasePlayback|x86.Build.0 = ReleasePlayback|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/PCH/pch.vcxproj
+++ b/Source/PCH/pch.vcxproj
@@ -9,6 +9,10 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleasePlayback|x64">
+      <Configuration>ReleasePlayback</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -28,6 +32,9 @@
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='ReleasePlayback'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='DebugFast'" Label="Configuration">


### PR DESCRIPTION
`cmake -DIS_PLAYBACK=ON ../` will now let you build a specific build with playback changes.

I was considering whether it would be better to do it in cmake or make, open to suggestions.