### PR TITLE
Clean up Linux user.json path

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -794,8 +794,8 @@ std::string GetSysDirectory()
 	if (!home) home = "";
 	std::string home_path = std::string(home) + DIR_SEP;
 	const char* config_home = getenv("XDG_CONFIG_HOME");
-	sysDir = std::string(config_home && config_home[0] == '/' 
-		? config_home : (home_path + ".config")) 
+	sysDir = std::string(config_home && config_home[0] == '/'
+		? config_home : (home_path + ".config"))
 		+ DIR_SEP DOLPHIN_DATA_DIR DIR_SEP "Sys" DIR_SEP;
 #endif
 	INFO_LOG(COMMON, "GetSysDirectory: Setting to %s:", sysDir.c_str());

--- a/Source/Core/Core/Slippi/SlippiUser.cpp
+++ b/Source/Core/Core/Slippi/SlippiUser.cpp
@@ -228,6 +228,7 @@ std::string SlippiUser::getUserFilePath()
 	std::string dirPath = File::GetExeDirectory();
 #else
 	std::string dirPath = File::GetSysDirectory();
+	dirPath.pop_back();
 #endif
 	std::string userFilePath = dirPath + DIR_SEP + "user.json";
 	return userFilePath;


### PR DESCRIPTION
Removes an extra slash in the user.json path for Linux.

Before
![image](https://user-images.githubusercontent.com/6331403/87202407-59d19d00-c2b5-11ea-93dc-95f7343322ae.png)

After
![image](https://user-images.githubusercontent.com/6331403/87202444-6eae3080-c2b5-11ea-95ff-5bea0f70fc90.png)
