### PR TITLE
Open changelog url before we run the updater.

### DIFF
--- a/Source/Core/Core/Slippi/SlippiUser.cpp
+++ b/Source/Core/Core/Slippi/SlippiUser.cpp
@@ -61,6 +61,19 @@ SlippiUser::~SlippiUser()
 		fileListenThread.join();
 }
 
+void SlippiUser::OpenLink(std::string link)
+{
+#ifdef _WIN32
+	std::string command = "explorer \"" + link + "\"";
+#elif defined(__APPLE__)
+	std::string command = "open \"" + link + "\"";
+#else
+	std::string command = "xdg-open \"" + link + "\""; // Linux
+#endif
+
+	RunSystemCommand(command);
+}
+
 bool SlippiUser::AttemptLogin()
 {
 	std::string userFilePath = getUserFilePath();
@@ -76,7 +89,7 @@ bool SlippiUser::AttemptLogin()
 			if (File::Exists(userFilePath))
 			{
 				INFO_LOG(SLIPPI_ONLINE,
-						 "Found both .json.txt and .json file for user data. Using .json and ignoring the .json.txt");
+				         "Found both .json.txt and .json file for user data. Using .json and ignoring the .json.txt");
 			}
 			// If only the .txt file exists move the contents to a json file and log if it fails
 			else if (!File::Rename(userFilePathTxt, userFilePath))
@@ -114,16 +127,6 @@ void SlippiUser::OpenLogInPage()
 	path = ReplaceAll(path, "\\", folderSep);
 	path = ReplaceAll(path, "/", folderSep);
 	std::string fullUrl = url + "?path=" + path;
-
-#ifdef _WIN32
-	std::string command = "explorer \"" + fullUrl + "\"";
-#elif defined(__APPLE__)
-	std::string command = "open \"" + fullUrl + "\"";
-#else
-	std::string command = "xdg-open \"" + fullUrl + "\""; // Linux
-#endif
-
-	RunSystemCommand(command);
 }
 
 void SlippiUser::UpdateFile()
@@ -142,6 +145,7 @@ void SlippiUser::UpdateFile()
 
 void SlippiUser::UpdateApp()
 {
+	OpenLink("https://github.com/project-slippi/ishiiruka/releases/latest");
 #ifdef _WIN32
 	auto isoPath = SConfig::GetInstance().m_strFilename;
 

--- a/Source/Core/Core/Slippi/SlippiUser.h
+++ b/Source/Core/Core/Slippi/SlippiUser.h
@@ -20,6 +20,7 @@ class SlippiUser
 
 	~SlippiUser();
 
+	void OpenLink(std::string);
 	bool AttemptLogin();
 	void OpenLogInPage();
 	void UpdateFile();


### PR DESCRIPTION
With the amount of users coming into the discord to ask about breaking changes mentioned in the changelog (i.e. replay location), I figured it would be useful to make the changelog more available by having it be opened when the application is updated.