### PR TITLE
Fix controller calibration when playing offline

### DIFF
--- a/Source/Core/Core/HW/SI.cpp
+++ b/Source/Core/Core/HW/SI.cpp
@@ -603,15 +603,11 @@ void UpdateDevices()
 	// Update inputs at 240 hz
 	g_controller_interface.UpdateInput();
 
+	// The adapter needs to update what devices are connected
+	GCAdapter::UpdateDevices();
+
 	if(SConfig::GetInstance().iPollingMethod == POLLING_ONSIREAD)
 	{
-		// We need to always update the GC adapter, so that it can know what ports are plugged in
-		if(!NetPlay::IsNetPlayRunning())
-		{
-			for(int i = 0; i < 4; i++)
-				GCAdapter::Input(i);
-		}
-
 		// Pretend that there's always new data
 		g_StatusReg.RDST0 = g_StatusReg.RDST1 = g_StatusReg.RDST2 = g_StatusReg.RDST3 = true;
 	}

--- a/Source/Core/InputCommon/GCAdapter.h
+++ b/Source/Core/InputCommon/GCAdapter.h
@@ -30,6 +30,7 @@ void StartScanThread();
 void StopScanThread();
 GCPadStatus Input(int chan);
 void Output(int chan, u8 rumble_command);
+void UpdateDevices();
 bool IsDetected();
 bool IsDriverDetected();
 bool DeviceConnected(int chan);


### PR DESCRIPTION
Controller calibration was broken by 3abe679077771cf3ba6665d085a99b520f789d85 when playing offline and Polling Method is set to "On SI Read". 

The reason is that the adapter *both* updates device status and reads inputs in `GCAdapter::Input`, when it first encounters a new controller it sends `PAD_GET_ORIGIN` to the game. Normally the adapter would be polled 120 times a second and the game would receive every other input, but when "On SI Read" is enabled `GCAdapter::Input` has to be called both in the normal input loop (`SerialInterface::UpdateDevices`) and in the SI register read code (since the game wouldn't start polling until it received the notification that a device was plugged in!). The game would never receive the first input with the "get origin" bit since it's thrown away in `SerialInterface::UpdateDevices`.

This commit separates updating device status and reading inputs into two different functions. `GCAdapter::UpdateDevices` is called in `SerialInterface::UpdateDevices` even if the game isn't reading inputs. It sets a flag that `PAD_GET_ORIGIN` should be sent the first time the game actually receives an input. `GCAdapter::Input` is only called when the game reads from the SI register. 

(This issue never affected FM since devices were enabled/disabled in the netplay interface)