### PR TITLE
Fix cubeb CMake error during Linux install

### DIFF
--- a/Externals/cubeb/CMakeLists.txt
+++ b/Externals/cubeb/CMakeLists.txt
@@ -62,7 +62,7 @@ target_include_directories(cubeb
   PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/exports>
 )
 
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/include DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include DESTINATION ${CMAKE_INSTALL_PREFIX})
 install(DIRECTORY ${CMAKE_BINARY_DIR}/exports/ DESTINATION ${CMAKE_INSTALL_PREFIX}/include/cubeb)
 
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
This is a small fix to the following cubeb CMake error when installing on Linux:

```
CMake Error at Externals/cubeb/cmake_install.cmake:49 (file):
  file INSTALL cannot find "/home/ari/Documents/Games/Ishiiruka/include": No
  such file or directory.
Call Stack (most recent call first):
  cmake_install.cmake:122 (include)
```

Credit goes to: https://gist.github.com/disassembler/9c4fad684600d60d9aba2733b315b639