### PR TITLE
Default macOS to 1x

### DIFF
--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -132,7 +132,14 @@ void VideoConfig::Load(const std::string& ini_file)
 
 	settings->Get("FastDepthCalc", &bFastDepthCalc, true);
 	settings->Get("MSAA", &iMultisamples, 1);
+
+// Retina displays on macOS seemingly have worse performance when defaulted to @2x.
+#ifdef __WXOSX__
+	settings->Get("EFBScale", &iEFBScale, (int)SCALE_1X);
+#else
 	settings->Get("EFBScale", &iEFBScale, (int)SCALE_2X);
+#endif
+
 	settings->Get("TexFmtOverlayEnable", &bTexFmtOverlayEnable, 0);
 	settings->Get("TexFmtOverlayCenter", &bTexFmtOverlayCenter, 0);
 	settings->Get("WireFrame", &bWireFrame, 0);

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -134,7 +134,7 @@ void VideoConfig::Load(const std::string& ini_file)
 	settings->Get("MSAA", &iMultisamples, 1);
 
 // Retina displays on macOS seemingly have worse performance when defaulted to @2x.
-#ifdef __WXOSX__
+#ifdef __APPLE__
 	settings->Get("EFBScale", &iEFBScale, (int)SCALE_1X);
 #else
 	settings->Get("EFBScale", &iEFBScale, (int)SCALE_2X);


### PR DESCRIPTION
Kept meaning to do this - enough people seem to need to set this to 1x in the support channel to get acceptable performance so it's worth looking at default macOS back to 1x. If I had to hazard a guess this'd be something to do with the Retina display, but don't quote me on it.