### PR TITLE
Block non-Melee games from running

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -245,6 +245,15 @@ bool BootCore(const std::string& _rFilename)
 	if (!StartUp.AutoSetup(SConfig::BOOT_DEFAULT))
 		return false;
 
+	// Block running anything other than Melee and homebrew
+	if (!StartUp.GetGameID().empty() && !StartUp.GameHasDefaultGameIni())
+	{
+		PanicAlertT("This does not seem to be a copy of Super Smash Bros. Melee. "
+		            "Please use regular Dolphin (https://dolphin-emu.org/) for running "
+		            "games other than Super Smash Bros. Melee.");
+		return false;
+	}
+
 	// Load game specific settings
 	{
 		IniFile game_ini = StartUp.LoadGameIni();

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <cinttypes>
 #include <climits>
 #include <memory>
@@ -1156,7 +1157,10 @@ std::string SConfig::GetGameID_Wrapper() const
 	return m_gameType == GAMETYPE_MELEE_20XX ? "GALEXX" : GetGameID();
 }
 
-
+bool SConfig::GameHasDefaultGameIni() const
+{
+	return GameHasDefaultGameIni(GetGameID_Wrapper(), m_revision);
+}
 
 IniFile SConfig::LoadDefaultGameIni() const
 {
@@ -1171,6 +1175,14 @@ IniFile SConfig::LoadLocalGameIni() const
 IniFile SConfig::LoadGameIni() const
 {
 	return LoadGameIni(GetGameID_Wrapper(), m_revision);
+}
+
+bool SConfig::GameHasDefaultGameIni(const std::string& id, u16 revision)
+{
+	const std::vector<std::string> filenames = GetGameIniFilenames(id, revision);
+	return std::any_of(filenames.begin(), filenames.end(), [](const std::string& filename) {
+		return File::Exists(File::GetSysDirectory() + GAMESETTINGS_DIR DIR_SEP + filename);
+	});
 }
 
 IniFile SConfig::LoadDefaultGameIni(const std::string& id, u16 revision)

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -260,10 +260,12 @@ struct SConfig : NonCopyable
 
 	u16 GetGameRevision() const;
 	std::string GetGameID_Wrapper() const;
+	bool GameHasDefaultGameIni() const;
 	IniFile LoadDefaultGameIni() const;
 	IniFile LoadLocalGameIni() const;
 	IniFile LoadGameIni() const;
 
+	static bool GameHasDefaultGameIni(const std::string& id, u16 revision);
 	static IniFile LoadDefaultGameIni(const std::string& id, u16 revision);
 	static IniFile LoadLocalGameIni(const std::string& id, u16 revision);
 	static IniFile LoadGameIni(const std::string& id, u16 revision);


### PR DESCRIPTION
Now that game INIs are not being shipped for games other than Melee, Slippi Dolphin is not suitable for running games other than Melee. With this change, I'm especially trying to stop people from falling into the trap of thinking Slippi is better at running non-Melee games than normal versions of Dolphin because the games run faster, even though this speedup only happens because settings required by the game have not been set.

I included a carve-out to not block homebrew programs, in case someone wants to run something like a controller test. Homebrew programs don't have game INIs in any version of Dolphin anyway.