### PR TITLE
Prevent macOS from going to sleep (screensaver or display sleep) when playing a game

### DIFF
--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -115,7 +115,7 @@ public:
 	void DoFullscreen(bool enable_fullscreen);
 	void DoExclusiveFullscreen(bool enable_fullscreen);
 	void ToggleDisplayMode(bool bFullscreen);
-    void ToggleScreenSaver(bool enable);
+	void ToggleScreenSaver(bool enable);
 	static void ConnectWiimote(int wm_idx, bool connect);
 	void UpdateTitle(const std::string& str);
 	void OpenGeneralConfiguration(wxWindowID tab_id = wxID_ANY);

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -115,6 +115,7 @@ public:
 	void DoFullscreen(bool enable_fullscreen);
 	void DoExclusiveFullscreen(bool enable_fullscreen);
 	void ToggleDisplayMode(bool bFullscreen);
+    void ToggleScreenSaver(bool enable);
 	static void ConnectWiimote(int wm_idx, bool connect);
 	void UpdateTitle(const std::string& str);
 	void OpenGeneralConfiguration(wxWindowID tab_id = wxID_ANY);

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -86,6 +86,10 @@
 
 #include "Common/Logging/Log.h"
 
+#if defined(__APPLE__)
+#include <IOKit/pwr_mgt/IOPMLib.h>
+#endif
+
 class InputConfig;
 class wxFrame;
 
@@ -612,6 +616,32 @@ void CFrame::ToggleDisplayMode(bool bFullscreen)
 #endif
 }
 
+void CFrame::ToggleScreenSaver(bool enable)
+{
+#if defined(__APPLE__)
+    static IOPMAssertionID s_power_assertion = kIOPMNullAssertionID;
+
+    if (enable)
+    {
+        if (s_power_assertion != kIOPMNullAssertionID)
+        {
+            IOPMAssertionRelease(s_power_assertion);
+            s_power_assertion = kIOPMNullAssertionID;
+        }
+    }
+    else
+    {
+        CFStringRef reason_for_activity = CFSTR("Slippi Running");
+        if (IOPMAssertionCreateWithName(kIOPMAssertionTypePreventUserIdleDisplaySleep,
+                    kIOPMAssertionLevelOn, reason_for_activity,
+                    &s_power_assertion) != kIOReturnSuccess)
+        {
+            s_power_assertion = kIOPMNullAssertionID;
+        }
+    }
+#endif
+}
+
 // Prepare the GUI to start the game.
 void CFrame::StartGame(const std::string& filename)
 {
@@ -686,6 +716,7 @@ void CFrame::StartGame(const std::string& filename)
 
 	wxBusyCursor hourglass;
 
+    ToggleScreenSaver(false);
 	DoFullscreen(SConfig::GetInstance().bFullscreen);
 
 	if (!BootManager::BootCore(filename))
@@ -866,6 +897,8 @@ void CFrame::DoStop()
 		Core::Stop();
 		UpdateGUI();
 	}
+
+    ToggleScreenSaver(true);
 }
 
 void CFrame::DoExit()

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -619,26 +619,26 @@ void CFrame::ToggleDisplayMode(bool bFullscreen)
 void CFrame::ToggleScreenSaver(bool enable)
 {
 #if defined(__APPLE__)
-    static IOPMAssertionID s_power_assertion = kIOPMNullAssertionID;
+	static IOPMAssertionID s_power_assertion = kIOPMNullAssertionID;
 
-    if (enable)
-    {
-        if (s_power_assertion != kIOPMNullAssertionID)
-        {
-            IOPMAssertionRelease(s_power_assertion);
-            s_power_assertion = kIOPMNullAssertionID;
-        }
-    }
-    else
-    {
-        CFStringRef reason_for_activity = CFSTR("Slippi Running");
-        if (IOPMAssertionCreateWithName(kIOPMAssertionTypePreventUserIdleDisplaySleep,
-                    kIOPMAssertionLevelOn, reason_for_activity,
-                    &s_power_assertion) != kIOReturnSuccess)
-        {
-            s_power_assertion = kIOPMNullAssertionID;
-        }
-    }
+	if (enable)
+	{
+		if (s_power_assertion != kIOPMNullAssertionID)
+		{
+			IOPMAssertionRelease(s_power_assertion);
+			s_power_assertion = kIOPMNullAssertionID;
+		}
+	}
+	else
+	{
+		CFStringRef reason_for_activity = CFSTR("Slippi Running");
+		if (IOPMAssertionCreateWithName(kIOPMAssertionTypePreventUserIdleDisplaySleep,
+					kIOPMAssertionLevelOn, reason_for_activity,
+					&s_power_assertion) != kIOReturnSuccess)
+		{
+			s_power_assertion = kIOPMNullAssertionID;
+		}
+	}
 #endif
 }
 
@@ -716,7 +716,7 @@ void CFrame::StartGame(const std::string& filename)
 
 	wxBusyCursor hourglass;
 
-    ToggleScreenSaver(false);
+	ToggleScreenSaver(false);
 	DoFullscreen(SConfig::GetInstance().bFullscreen);
 
 	if (!BootManager::BootCore(filename))
@@ -898,7 +898,7 @@ void CFrame::DoStop()
 		UpdateGUI();
 	}
 
-    ToggleScreenSaver(true);
+	ToggleScreenSaver(true);
 }
 
 void CFrame::DoExit()


### PR DESCRIPTION
This is actually present in Mainline as an option (and a good chunk of the code is lifted from there). Here, considering universally nobody should want their display to sleep while playing online... I just default to it.

Not sure about the story for this on Windows/Linux but theoretically that could be brought over too.