### PR TITLE
Rename on macOS (Dolphin.app -> Slippi Dolphin.app)

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -356,10 +356,10 @@ jobs:
         run: |
           FILE_NAME=${{ env.CURR_DATE }}-${{ env.GIT_HASH }}-${{ env.GIT_TAG }}-macOS-netplay.tar.gz
           echo "::set-env name=FILE_NAME::${FILE_NAME}"
-          cp -Rf Data/Sys build/Binaries/Dolphin.app/Contents/Resources/
+          cp -Rf Data/Sys build/Binaries/Slippi\ Dolphin.app/Contents/Resources/
           mkdir artifact
           cd ./build/Binaries/
-          zip -r "${FILE_NAME}" Dolphin.app
+          zip -r "${FILE_NAME}" Slippi\ Dolphin.app
           mv "${FILE_NAME}" ../../artifact/
       - name: "Publish"
         if: success()
@@ -443,11 +443,11 @@ jobs:
           mkdir artifact
           git clone https://github.com/project-slippi/slippi-desktop-app
           cd ./build/Binaries/
-          cp -Rf ../../Data/Sys ./Dolphin.app/Contents/Resources
-          cp -Rf ../../slippi-desktop-app/app/dolphin-dev/overwrite/Sys ./Dolphin.app/Contents/Resources
-          cp -Rf ../../slippi-desktop-app/app/dolphin-dev/overwrite/User ./Dolphin.app/Contents/Resources
+          cp -Rf ../../Data/Sys ./Slippi\ Dolphin.app/Contents/Resources
+          cp -Rf ../../slippi-desktop-app/app/dolphin-dev/overwrite/Sys ./Slippi\ Dolphin.app/Contents/Resources
+          cp -Rf ../../slippi-desktop-app/app/dolphin-dev/overwrite/User ./Slippi\ Dolphin.app/Contents/Resources
           FILE_NAME=${{ env.CURR_DATE }}-${{ env.GIT_HASH }}-${{ env.GIT_TAG }}-macOS-playback.zip
-          zip -r "${FILE_NAME}" Dolphin.app
+          zip -r "${FILE_NAME}" Slippi\ Dolphin.app
           mv "${FILE_NAME}" ../../artifact/
       - name: "Publish"
         if: success()

--- a/Source/Core/Core/Slippi/SlippiUser.cpp
+++ b/Source/Core/Core/Slippi/SlippiUser.cpp
@@ -143,23 +143,24 @@ bool SlippiUser::AttemptLogin()
 
 void SlippiUser::OpenLogInPage()
 {
-#ifdef _WIN32
-	std::string folderSep = "%5C";
-#elif defined(__APPLE__)
-#else
-	std::string folderSep = "%2F";
-#endif
-
 	std::string url = "https://slippi.gg/online/enable";
 	std::string path = getUserFilePath();
 
-#if defined(__APPLE__)
-#else
-	path = ReplaceAll(path, "\\", folderSep);
-    path = ReplaceAll(path, "/", folderSep);
+#ifdef _WIN32
+	// On windows, sometimes the path can have backslashes and slashes mixed, convert all to backslashes
+	path = ReplaceAll(path, "\\", "\\");
+	path = ReplaceAll(path, "/", "\\");
 #endif
-	
-    std::string fullUrl = url + "?path=" + path;
+
+#ifndef __APPLE__
+	char *escapedPath = curl_easy_escape(m_curl, path.c_str(), (int)path.length());
+	path = std::string(escapedPath);
+	curl_free(escapedPath);
+#endif
+
+	std::string fullUrl = url + "?path=" + path;
+
+	INFO_LOG(SLIPPI_ONLINE, "[User] Login at path: %s", fullUrl);
 
 #ifdef _WIN32
 	std::string command = "explorer \"" + fullUrl + "\"";

--- a/Source/Core/Core/Slippi/SlippiUser.cpp
+++ b/Source/Core/Core/Slippi/SlippiUser.cpp
@@ -160,7 +160,7 @@ void SlippiUser::OpenLogInPage()
 
 	std::string fullUrl = url + "?path=" + path;
 
-	INFO_LOG(SLIPPI_ONLINE, "[User] Login at path: %s", fullUrl);
+	INFO_LOG(SLIPPI_ONLINE, "[User] Login at path: %s", fullUrl.c_str());
 
 #ifdef _WIN32
 	std::string command = "explorer \"" + fullUrl + "\"";

--- a/Source/Core/Core/Slippi/SlippiUser.cpp
+++ b/Source/Core/Core/Slippi/SlippiUser.cpp
@@ -145,15 +145,21 @@ void SlippiUser::OpenLogInPage()
 {
 #ifdef _WIN32
 	std::string folderSep = "%5C";
+#elif defined(__APPLE__)
 #else
 	std::string folderSep = "%2F";
 #endif
 
 	std::string url = "https://slippi.gg/online/enable";
 	std::string path = getUserFilePath();
+
+#if defined(__APPLE__)
+#else
 	path = ReplaceAll(path, "\\", folderSep);
-	path = ReplaceAll(path, "/", folderSep);
-	std::string fullUrl = url + "?path=" + path;
+    path = ReplaceAll(path, "/", folderSep);
+#endif
+	
+    std::string fullUrl = url + "?path=" + path;
 
 #ifdef _WIN32
 	std::string command = "explorer \"" + fullUrl + "\"";

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -108,7 +108,7 @@ if(APPLE)
 endif()
 
 if(APPLE)
-    set(DOLPHIN_EXE_BASE "Slippi Dolphin")
+	set(DOLPHIN_EXE_BASE "Slippi Dolphin")
 else()
 	set(DOLPHIN_EXE_BASE dolphin-emu)
 endif()
@@ -128,7 +128,7 @@ if(wxWidgets_FOUND)
 	if(APPLE)
 		include(BundleUtilities)
 		set(BUNDLE_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/"${DOLPHIN_EXE}".app)
-        string(REPLACE "\"" "" BUNDLE_PATH_NO_QUOTES ${BUNDLE_PATH})
+		string(REPLACE "\"" "" BUNDLE_PATH_NO_QUOTES ${BUNDLE_PATH})
 
 		# Ask for an application bundle.
 		set_target_properties(${DOLPHIN_EXE} PROPERTIES
@@ -144,19 +144,19 @@ if(wxWidgets_FOUND)
 			# so we invoke CMake again on a generated script.
 			file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/postprocess_bundle.cmake "
 				include(BundleUtilities)
-                message(\"Fixing up application bundle: ${BUNDLE_PATH_NO_QUOTES}\")
+				message(\"Fixing up application bundle: ${BUNDLE_PATH_NO_QUOTES}\")
 				message(\"(Note: This is only necessary to produce a redistributable binary.\")
 				message(\"To skip, pass -DSKIP_POSTPROCESS_BUNDLE=1 to cmake.)\")
 				set(BU_CHMOD_BUNDLE_ITEMS ON)
 				execute_process(
-                    COMMAND ${CMAKE_SOURCE_DIR}/Tools/deploy-mac.py \"${BUNDLE_PATH_NO_QUOTES}\"
+					COMMAND ${CMAKE_SOURCE_DIR}/Tools/deploy-mac.py \"${BUNDLE_PATH_NO_QUOTES}\"
 					RESULT_VARIABLE retcode
 				)
 				if(NOT \${retcode} EQUAL 0)
 					message(FATAL_ERROR \"Error when postprocessing bundle (return code: \${retcode}).\")
 				endif()
 				file(INSTALL \"${CMAKE_SOURCE_DIR}/Data/Sys\"
-                    DESTINATION \"${BUNDLE_PATH_NO_QUOTES}/Contents/Resources\"
+					DESTINATION \"${BUNDLE_PATH_NO_QUOTES}/Contents/Resources\"
 					)
 				")
 			add_custom_command(TARGET ${DOLPHIN_EXE} POST_BUILD
@@ -184,12 +184,12 @@ if(wxWidgets_FOUND)
 					# It would be better to copy to the new name as a single action,
 					# but I can't figure out a way to let CMake do that.
 					file(COPY ${CMAKE_CURRENT_BINARY_DIR}/\${TRANSLATION_FILE}
-                        DESTINATION \"${BUNDLE_PATH_NO_QUOTES}/Contents/Resources/\${TRANSLATION_DIR}\"
+						DESTINATION \"${BUNDLE_PATH_NO_QUOTES}/Contents/Resources/\${TRANSLATION_DIR}\"
 						NO_SOURCE_PERMISSIONS
 						)
 					file(RENAME
-                        \"${BUNDLE_PATH_NO_QUOTES}/Contents/Resources/\${TRANSLATION_DIR}/\${TRANSLATION_FILE}\"
-                        \"${BUNDLE_PATH_NO_QUOTES}/Contents/Resources/\${TRANSLATION_DIR}/dolphin-emu.mo\"
+						\"${BUNDLE_PATH_NO_QUOTES}/Contents/Resources/\${TRANSLATION_DIR}/\${TRANSLATION_FILE}\"
+						\"${BUNDLE_PATH_NO_QUOTES}/Contents/Resources/\${TRANSLATION_DIR}/dolphin-emu.mo\"
 						)
 				endforeach(TRANSLATION_FILE)
 				")

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -108,7 +108,7 @@ if(APPLE)
 endif()
 
 if(APPLE)
-	set(DOLPHIN_EXE_BASE Dolphin)
+    set(DOLPHIN_EXE_BASE "Slippi Dolphin")
 else()
 	set(DOLPHIN_EXE_BASE dolphin-emu)
 endif()
@@ -123,11 +123,12 @@ if(GETTEXT_MSGMERGE_EXECUTABLE AND GETTEXT_MSGFMT_EXECUTABLE AND wxWidgets_FOUND
 endif()
 
 if(wxWidgets_FOUND)
-	add_executable(${DOLPHIN_EXE} ${SRCS} ${GUI_SRCS})
-	target_link_libraries(${DOLPHIN_EXE} ${LIBS} ${WXLIBS})
+	add_executable("${DOLPHIN_EXE}" ${SRCS} ${GUI_SRCS})
+	target_link_libraries("${DOLPHIN_EXE}" ${LIBS} ${WXLIBS})
 	if(APPLE)
 		include(BundleUtilities)
-		set(BUNDLE_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${DOLPHIN_EXE}.app)
+		set(BUNDLE_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/"${DOLPHIN_EXE}".app)
+        string(REPLACE "\"" "" BUNDLE_PATH_NO_QUOTES ${BUNDLE_PATH})
 
 		# Ask for an application bundle.
 		set_target_properties(${DOLPHIN_EXE} PROPERTIES
@@ -143,19 +144,19 @@ if(wxWidgets_FOUND)
 			# so we invoke CMake again on a generated script.
 			file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/postprocess_bundle.cmake "
 				include(BundleUtilities)
-				message(\"Fixing up application bundle: ${BUNDLE_PATH}\")
+                message(\"Fixing up application bundle: ${BUNDLE_PATH_NO_QUOTES}\")
 				message(\"(Note: This is only necessary to produce a redistributable binary.\")
 				message(\"To skip, pass -DSKIP_POSTPROCESS_BUNDLE=1 to cmake.)\")
 				set(BU_CHMOD_BUNDLE_ITEMS ON)
 				execute_process(
-					COMMAND ${CMAKE_SOURCE_DIR}/Tools/deploy-mac.py \"${BUNDLE_PATH}\"
+                    COMMAND ${CMAKE_SOURCE_DIR}/Tools/deploy-mac.py \"${BUNDLE_PATH_NO_QUOTES}\"
 					RESULT_VARIABLE retcode
 				)
 				if(NOT \${retcode} EQUAL 0)
 					message(FATAL_ERROR \"Error when postprocessing bundle (return code: \${retcode}).\")
 				endif()
 				file(INSTALL \"${CMAKE_SOURCE_DIR}/Data/Sys\"
-					DESTINATION \"${BUNDLE_PATH}/Contents/Resources\"
+                    DESTINATION \"${BUNDLE_PATH_NO_QUOTES}/Contents/Resources\"
 					)
 				")
 			add_custom_command(TARGET ${DOLPHIN_EXE} POST_BUILD
@@ -183,12 +184,12 @@ if(wxWidgets_FOUND)
 					# It would be better to copy to the new name as a single action,
 					# but I can't figure out a way to let CMake do that.
 					file(COPY ${CMAKE_CURRENT_BINARY_DIR}/\${TRANSLATION_FILE}
-						DESTINATION ${BUNDLE_PATH}/Contents/Resources/\${TRANSLATION_DIR}
+                        DESTINATION \"${BUNDLE_PATH_NO_QUOTES}/Contents/Resources/\${TRANSLATION_DIR}\"
 						NO_SOURCE_PERMISSIONS
 						)
 					file(RENAME
-						${BUNDLE_PATH}/Contents/Resources/\${TRANSLATION_DIR}/\${TRANSLATION_FILE}
-						${BUNDLE_PATH}/Contents/Resources/\${TRANSLATION_DIR}/dolphin-emu.mo
+                        \"${BUNDLE_PATH_NO_QUOTES}/Contents/Resources/\${TRANSLATION_DIR}/\${TRANSLATION_FILE}\"
+                        \"${BUNDLE_PATH_NO_QUOTES}/Contents/Resources/\${TRANSLATION_DIR}/dolphin-emu.mo\"
 						)
 				endforeach(TRANSLATION_FILE)
 				")

--- a/Source/Core/DolphinWX/Info.plist.in
+++ b/Source/Core/DolphinWX/Info.plist.in
@@ -2,39 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDocumentTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>ciso</string>
-				<string>dol</string>
-				<string>elf</string>
-				<string>gcm</string>
-				<string>gcz</string>
-				<string>iso</string>
-				<string>tgc</string>
-				<string>wad</string>
-				<string>wbfs</string>
-			</array>
-			<key>CFBundleTypeIconFile</key>
-			<string>Dolphin.icns</string>
-			<key>CFBundleTypeName</key>
-			<string>Nintendo GC/Wii file</string>
-			<key>CFBundleTypeRole</key>
-			<string>Viewer</string>
-		</dict>
-	</array>
 	<key>CFBundleExecutable</key>
 	<string>Slippi Dolphin</string>
-    <key>CFBundleName<key>
+    <key>CFBundleName</key>
     <string>Slippi Dolphin</string>
     <key>CFBundleDisplayName</key>
     <string>Slippi Dolphin</string>
 	<key>CFBundleIconFile</key>
 	<string>Dolphin.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.dolphin-emu.dolphin</string>
+	<string>com.project-slippi.dolphin</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleLocalizations</key>

--- a/Source/Core/DolphinWX/Info.plist.in
+++ b/Source/Core/DolphinWX/Info.plist.in
@@ -4,10 +4,10 @@
 <dict>
 	<key>CFBundleExecutable</key>
 	<string>Slippi Dolphin</string>
-    <key>CFBundleName</key>
-    <string>Slippi Dolphin</string>
-    <key>CFBundleDisplayName</key>
-    <string>Slippi Dolphin</string>
+	<key>CFBundleName</key>
+	<string>Slippi Dolphin</string>
+	<key>CFBundleDisplayName</key>
+	<string>Slippi Dolphin</string>
 	<key>CFBundleIconFile</key>
 	<string>Dolphin.icns</string>
 	<key>CFBundleIdentifier</key>

--- a/Source/Core/DolphinWX/Info.plist.in
+++ b/Source/Core/DolphinWX/Info.plist.in
@@ -26,7 +26,11 @@
 		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
-	<string>Dolphin</string>
+	<string>Slippi Dolphin</string>
+    <key>CFBundleName<key>
+    <string>Slippi Dolphin</string>
+    <key>CFBundleDisplayName</key>
+    <string>Slippi Dolphin</string>
 	<key>CFBundleIconFile</key>
 	<string>Dolphin.icns</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Changes the built app to be `Slippi Dolphin.app`, which should:

- Make it so there's no collision with existing Dolphin, be it mainline or other
- Reduce some confusion for new users who go to place their `user.json` and don't realize that Slippi, if there's an existing Dolphin.app, becomes `Dolphin (2).app` (or some such variant).
- Make it so that an auto-updater wouldn't obliterate a Dolphin installation.

I fully expect the CI to fail on this out the gate lol