### PR TITLE
Add command line option to specify directory for .avi and .wav dumps

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -216,9 +216,16 @@ void SendAIBuffer(const short* samples, unsigned int num_samples)
 void StartAudioDump()
 {
   std::string audio_file_name_dtk = File::GetUserPath(D_DUMPAUDIO_IDX) + "dtkdump.wav";
-  std::string audio_file_name_dsp = File::GetUserPath(D_DUMPAUDIO_IDX) + "dspdump.wav";
+  std::string s_dump_directory;
+  std::string audio_file_name_dsp;
+  if (!SConfig::GetInstance().m_strOutputDirectory.empty())
+	  s_dump_directory = SConfig::GetInstance().m_strOutputDirectory;
+  else
+	  s_dump_directory = File::GetUserPath(D_DUMPAUDIO_IDX);
   if (!SConfig::GetInstance().m_strOutputFilenameBase.empty())
-	  audio_file_name_dsp = File::GetUserPath(D_DUMPAUDIO_IDX) + SConfig::GetInstance().m_strOutputFilenameBase + ".wav";
+	  audio_file_name_dsp = s_dump_directory + SConfig::GetInstance().m_strOutputFilenameBase + ".wav";
+  else
+	  audio_file_name_dsp = s_dump_directory + "dspdump.wav";
   File::CreateFullPath(audio_file_name_dtk);
   File::CreateFullPath(audio_file_name_dsp);
   g_sound_stream->GetMixer()->StartLogDTKAudio(audio_file_name_dtk);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -233,6 +233,7 @@ struct SConfig : NonCopyable
 
 	std::string m_strVideoBackend;
 	std::string m_strSlippiInput;
+	std::string m_strOutputDirectory;
 	std::string m_strOutputFilenameBase;
 	std::string m_strGPUDeterminismMode;
 

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -147,6 +147,14 @@ bool DolphinApp::OnInit()
 		SConfig::GetInstance().m_coutEnabled = true;
 #endif
 
+	if (m_select_output_directory && !m_output_directory.empty())
+        {
+                std::string output_directory = WxStrToStr(m_output_directory);
+                if (output_directory.back() != '/')
+                        output_directory = output_directory + "/";
+		SConfig::GetInstance().m_strOutputDirectory = output_directory;
+        }
+
 	if (m_select_output_filename_base && !m_output_filename_base.empty())
 		SConfig::GetInstance().m_strOutputFilenameBase = WxStrToStr(m_output_filename_base);
 
@@ -248,6 +256,8 @@ void DolphinApp::OnInitCmdLine(wxCmdLineParser& parser)
 			 wxCMD_LINE_PARAM_OPTIONAL},
 			{wxCMD_LINE_OPTION, "i", "slippi-input", "Path to Slippi replay config file (default: Slippi/playback.txt)", 
 			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
+			{wxCMD_LINE_OPTION, "od", "output-directory", "Directory to place audio and video dump files",
+			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
 			{wxCMD_LINE_OPTION, "o", "output-filename-base", "Base of filenames for audio and video dump files", 
 			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
 			{wxCMD_LINE_OPTION, "a", "audio_emulation", "Low level (LLE) or high level (HLE) audio",
@@ -325,6 +335,7 @@ bool DolphinApp::OnCmdLineParsed(wxCmdLineParser& parser)
 	m_hide_seekbar = parser.Found("hide-seekbar");
 	m_enable_cout = parser.Found("cout");
 #endif
+	m_select_output_directory = parser.Found("output-directory", &m_output_directory);
 	m_select_output_filename_base = parser.Found("output-filename-base", &m_output_filename_base);
 	m_play_movie = parser.Found("movie", &m_movie_file);
 	parser.Found("user", &m_user_path);

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -150,7 +150,7 @@ bool DolphinApp::OnInit()
 	if (m_select_output_directory && !m_output_directory.empty())
         {
                 std::string output_directory = WxStrToStr(m_output_directory);
-                if (output_directory.back() != '/')
+                if (output_directory.back() != '/' && output_directory.back() != '\\')
                         output_directory = output_directory + "/";
 		SConfig::GetInstance().m_strOutputDirectory = output_directory;
         }

--- a/Source/Core/DolphinWX/Main.h
+++ b/Source/Core/DolphinWX/Main.h
@@ -48,6 +48,7 @@ private:
 	bool m_use_logger = false;
 	bool m_select_video_backend = false;
 	bool m_select_slippi_input = false;
+	bool m_select_output_directory = false;
 	bool m_select_output_filename_base = false;
 	bool m_select_audio_emulation = false;
 	bool m_hide_seekbar = false;
@@ -57,6 +58,7 @@ private:
 	wxString m_video_backend_name;
 	wxString m_audio_emulation_name;
 	wxString m_slippi_input_name;
+	wxString m_output_directory;
 	wxString m_output_filename_base;
 	wxString m_user_path;
 	wxString m_file_to_load;

--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -107,13 +107,19 @@ static std::string GetDumpPath(const std::string& format)
 	if (!g_Config.sDumpPath.empty())
 		return g_Config.sDumpPath;
 
+	std::string s_dump_directory;
 	std::string s_dump_path;
 
+	if (!SConfig::GetInstance().m_strOutputDirectory.empty())
+		s_dump_directory = SConfig::GetInstance().m_strOutputDirectory;
+	else
+		s_dump_directory = File::GetUserPath(D_DUMPFRAMES_IDX);
+
 	if (!SConfig::GetInstance().m_strOutputFilenameBase.empty())
-		s_dump_path = File::GetUserPath(D_DUMPFRAMES_IDX) + 
+		s_dump_path = s_dump_directory +
 			SConfig::GetInstance().m_strOutputFilenameBase + "." + format;
 	else
-		s_dump_path = File::GetUserPath(D_DUMPFRAMES_IDX) + "framedump" +
+		s_dump_path = s_dump_directory + "framedump" +
 			std::to_string(s_file_index) + "." + format;
 
 	// Ask to delete file


### PR DESCRIPTION
Usage:
```
./dolphin-emu -od OUTPUT_DIRECTORY
```
The result is that the .avi and .wav dumps will be saved to `OUTPUT_DIRECTORY`.