### PR TITLE
Playback: Fix empty first frame dump video

### DIFF
--- a/Source/Core/VideoCommon/AVIDump.cpp
+++ b/Source/Core/VideoCommon/AVIDump.cpp
@@ -84,6 +84,13 @@ static bool AVStreamCopyContext(AVStream* stream, AVCodecContext* codec_context)
 
 bool AVIDump::Start(int w, int h, bool fromBGRA)
 {
+#ifdef IS_PLAYBACK
+	if (!g_playbackStatus || !g_playbackStatus->inSlippiPlayback ||
+	    (g_playbackStatus->isHardFFW || g_playbackStatus->isSoftFFW) ||
+	    g_replayComm->current.startFrame >= g_playbackStatus->currentPlaybackFrame ||
+	    g_replayComm->current.endFrame <= g_playbackStatus->currentPlaybackFrame)
+		return false;
+#endif
 	s_pix_fmt = fromBGRA ? AV_PIX_FMT_BGRA : AV_PIX_FMT_RGBA;
 
 	s_width = w;

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -988,10 +988,12 @@ void Renderer::RunFrameDumps()
 					frame_dump_started = StartFrameDumpToAVI(config);
 				else
 					frame_dump_started = StartFrameDumpToImage(config);
-
+// just keep retrying if this is a playback build
+#ifndef IS_PLAYBACK
 				// Stop frame dumping if we fail to start.
 				if (!frame_dump_started)
 					SConfig::GetInstance().m_DumpFrames = false;
+#endif
 			}
 
 			// If we failed to start frame dumping, don't write a frame.


### PR DESCRIPTION
Currently, when dumping a replay dolphin will create a basically empty video and then when the replay actually starts it will create a second video with the actual replay dump. This fixes it by only creating the video file once we can see the game.