### PR TITLE
Fix Crash when opponent quits on Splash Screen

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.h
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.h
@@ -153,6 +153,7 @@ class CEXISlippi : public IEXIDevice
 
 	// online play stuff
 	u16 getRandomStage();
+	bool isDisconnected();
 	void handleOnlineInputs(u8 *payload);
 	void prepareOpponentInputs(u8 *payload);
 	void handleSendInputs(u8 *payload);


### PR DESCRIPTION
Fixes: https://github.com/project-slippi/Ishiiruka/issues/168

### Fix crash on player disconnect (from css or vs scene)

- Refactor inputs and capture methods to check if match has been disconnected
- Push disconnected state to game if that's the case before handling inputs.

### Cause
Bug was caused because disconnection was releasing slippi_netplay (causing it to be null) and the method that starts the game raised a null pointer while accessing it.