### PR TITLE
Add start/end game messages to spectator server

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -205,7 +205,6 @@ CEXISlippi::~CEXISlippi()
 	{
 		m_fileWriteThread.join();
 	}
-	m_slippiserver->write(&empty[0], 0);
 	m_slippiserver->endGame();
 
 	localSelections.Reset();
@@ -2158,7 +2157,23 @@ void CEXISlippi::DMAWrite(u32 _uAddr, u32 _uSize)
 		writeToFileAsync(&memPtr[0], receiveCommandsLen + 1, "create");
 		bufLoc += receiveCommandsLen + 1;
 		g_needInputForFrame = true;
-		m_slippiserver->startGame();
+
+		std::vector<std::string> codes;
+		if (slippi_netplay != nullptr)
+		{
+			if (slippi_netplay->IsDecider())
+			{
+				codes.push_back(user->GetUserInfo().connectCode);
+				codes.push_back(matchmaking->GetOpponent().connectCode);
+			}
+			else
+			{
+				codes.push_back(matchmaking->GetOpponent().connectCode);
+				codes.push_back(user->GetUserInfo().connectCode);
+			}
+		}
+
+		m_slippiserver->startGame(codes);
 		m_slippiserver->write(&memPtr[0], receiveCommandsLen + 1);
 	}
 

--- a/Source/Core/Core/Slippi/SlippiSpectate.cpp
+++ b/Source/Core/Core/Slippi/SlippiSpectate.cpp
@@ -130,9 +130,11 @@ void SlippiSpectateServer::popEvents()
 			}
 			if (json_message["type"] == "start_game")
 			{
+				m_game_count += 1;
 				m_event_buffer.clear();
 				m_in_game = true;
-				m_meta_event_buffer.push_back(event);
+				json_message["game_count"] = m_game_count;
+				m_meta_event_buffer.push_back(json_message.dump());
 				continue;
 			}
 		}
@@ -166,6 +168,7 @@ void SlippiSpectateServer::popEvents()
 			game_event["type"] = "game_event";
 			game_event["cursor"] = cursor;
 			game_event["next_cursor"] = cursor + 1;
+			game_event["game_count"] = m_game_count;
 			m_event_buffer.push_back(game_event.dump());
 
 			m_event_concat = "";
@@ -183,6 +186,7 @@ SlippiSpectateServer::SlippiSpectateServer()
 
 	m_in_game = false;
 	m_menu_cursor = 0;
+	m_game_count = 0;
 
 	// Spawn thread for socket listener
 	m_stop_socket_thread = false;
@@ -262,6 +266,7 @@ void SlippiSpectateServer::handleMessage(u8 *buffer, u32 length, u16 peer_id)
 			reply["nick"] = "Slippi Online";
 			reply["version"] = scm_slippi_semver_str;
 			reply["cursor"] = sent_cursor;
+			reply["game_count"] = m_game_count;
 
 			std::string packet_buffer = reply.dump();
 

--- a/Source/Core/Core/Slippi/SlippiSpectate.cpp
+++ b/Source/Core/Core/Slippi/SlippiSpectate.cpp
@@ -76,13 +76,6 @@ void SlippiSpectateServer::writeEvents(u16 peer_id)
 		m_sockets[peer_id]->m_menu_cursor = m_menu_cursor;
 	}
 
-	// Send meta events
-	for (auto& event : m_meta_event_buffer)
-	{
-		ENetPacket *packet = enet_packet_create(event.data(), event.length(), ENET_PACKET_FLAG_RELIABLE);
-		enet_peer_send(m_sockets[peer_id]->m_peer, 0, packet);
-	}
-
 	// Send game events
 	// Loop through each event that needs to be sent
 	//  send all the events starting at their cursor
@@ -101,6 +94,13 @@ void SlippiSpectateServer::writeEvents(u16 peer_id)
 		// Batch for sending
 		enet_peer_send(m_sockets[peer_id]->m_peer, 0, packet);
 		m_sockets[peer_id]->m_cursor++;
+	}
+
+	// Send meta events
+	for (auto& event : m_meta_event_buffer)
+	{
+		ENetPacket *packet = enet_packet_create(event.data(), event.length(), ENET_PACKET_FLAG_RELIABLE);
+		enet_peer_send(m_sockets[peer_id]->m_peer, 0, packet);
 	}
 }
 

--- a/Source/Core/Core/Slippi/SlippiSpectate.h
+++ b/Source/Core/Core/Slippi/SlippiSpectate.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <thread>
 
+#include <SlippiGame.h>
 #include "Common/FifoQueue.h"
 #include "nlohmann/json.hpp"
 #include <enet/enet.h>
@@ -49,7 +50,8 @@ class SlippiSpectateServer
 
 	// Should be called each time a new game starts.
 	//  This will clear out the old game event buffer and start a new one
-	void startGame();
+  //  argument is the list of player connect codes for the game. First one in the list is the "decider"
+	void startGame(std::vector<std::string> connect_codes);
 
 	// Clear the game event history buffer. Such as when a game ends.
 	//  The slippi server keeps a history of events in a buffer. So that
@@ -78,6 +80,7 @@ class SlippiSpectateServer
 	std::map<u16, std::shared_ptr<SlippiSocket>> m_sockets;
 	std::string m_event_concat = "";
 	std::vector<std::string> m_event_buffer;
+  std::vector<std::string> m_meta_event_buffer;
 	std::string m_menu_event;
 	// In order to emulate Wii behavior, the cursor position should be strictly
 	//  increasing. But internally, we need to index arrays by the cursor value.

--- a/Source/Core/Core/Slippi/SlippiSpectate.h
+++ b/Source/Core/Core/Slippi/SlippiSpectate.h
@@ -79,7 +79,6 @@ class SlippiSpectateServer
 	std::map<u16, std::shared_ptr<SlippiSocket>> m_sockets;
 	std::string m_event_concat = "";
 	std::vector<std::string> m_event_buffer;
-  std::vector<std::string> m_meta_event_buffer;
 	std::string m_menu_event;
 	// In order to emulate Wii behavior, the cursor position should be strictly
 	//  increasing. But internally, we need to index arrays by the cursor value.

--- a/Source/Core/Core/Slippi/SlippiSpectate.h
+++ b/Source/Core/Core/Slippi/SlippiSpectate.h
@@ -89,6 +89,7 @@ class SlippiSpectateServer
 	//  How many menu events have we sent so far? (Reset between matches)
 	//    Is used to know when a client hasn't been sent a menu event
 	u64 m_menu_cursor;
+	u64 m_game_count;
 
 	std::thread m_socketThread;
 

--- a/Source/Core/Core/Slippi/SlippiSpectate.h
+++ b/Source/Core/Core/Slippi/SlippiSpectate.h
@@ -5,7 +5,6 @@
 #include <map>
 #include <thread>
 
-#include <SlippiGame.h>
 #include "Common/FifoQueue.h"
 #include "nlohmann/json.hpp"
 #include <enet/enet.h>

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -236,7 +236,6 @@ bool DolphinApp::OnInit()
 
 	// Init the spectator server
 	SlippiSpectateServer *init = SlippiSpectateServer::getInstance();
-	init->endGame();
 
 	return true;
 }
@@ -263,7 +262,7 @@ void DolphinApp::OnInitCmdLine(wxCmdLineParser& parser)
 			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
 			{wxCMD_LINE_OPTION, "od", "output-directory", "Directory to place audio and video dump files",
 			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
-			{wxCMD_LINE_OPTION, "o", "output-filename-base", "Base of filenames for audio and video dump files", 
+			{wxCMD_LINE_OPTION, "o", "output-filename-base", "Base of filenames for audio and video dump files",
 			wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
 			{wxCMD_LINE_OPTION, "a", "audio_emulation", "Low level (LLE) or high level (HLE) audio",
 			 wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},


### PR DESCRIPTION
- Messages are not part of the cursor-indexed event buffer
- game_event with empty payload removed
- start_game message has optional "players" list for netplay matches, which lists the connect codes of the players. Example:

`{"type":"start_game", "players":[{"connect_code":"TEST#123","is_decider":true},{"connect_code":"TEST#321","is_decider":false}]}`