### PR TITLE
Improve Network stability

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -64,6 +64,7 @@
 #include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/State.h"
+#include "Core/Slippi/SlippiNetplay.h"
 
 #ifdef USE_GDBSTUB
 #include "Core/PowerPC/GDBStub.h"
@@ -83,6 +84,7 @@
 #else  // Everything besides OSX and Android
 #define ThreadLocalStorage thread_local
 #endif
+
 
 namespace Core
 {
@@ -190,8 +192,16 @@ bool IsRunning()
 	return (GetState() != CORE_UNINITIALIZED || s_hardware_initialized) && !s_is_stopping;
 }
 
+
+bool IsConnected()
+{
+    return SLIPPI_NETPLAY != nullptr;
+}
+
+
 bool IsRunningAndStarted()
 {
+
 	return s_is_started && !s_is_stopping;
 }
 
@@ -693,7 +703,11 @@ void SetState(EState state)
 	if (!IsRunningAndStarted())
 		return;
 
-	switch (state)
+	// Do not allow any kind of cpu pause/resum if we are connected to someone on slippi
+	if (IsConnected())
+	    return;
+
+    switch (state)
 	{
 	case CORE_PAUSE:
 		// NOTE: GetState() will return CORE_PAUSE immediately, even before anything has

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -192,13 +192,6 @@ bool IsRunning()
 	return (GetState() != CORE_UNINITIALIZED || s_hardware_initialized) && !s_is_stopping;
 }
 
-
-bool IsConnected()
-{
-    return SLIPPI_NETPLAY != nullptr;
-}
-
-
 bool IsRunningAndStarted()
 {
 
@@ -704,8 +697,8 @@ void SetState(EState state)
 		return;
 
 	// Do not allow any kind of cpu pause/resum if we are connected to someone on slippi
-	if (IsConnected())
-	    return;
+    if(IsOnline())
+        return;
 
     switch (state)
 	{
@@ -776,6 +769,7 @@ static std::string GenerateScreenshotName()
 
 void SaveScreenShot()
 {
+    if(IsOnline()) return;
 	const bool bPaused = (GetState() == CORE_PAUSE);
 
 	SetState(CORE_PAUSE);

--- a/Source/Core/Core/Slippi/SlippiNetplay.cpp
+++ b/Source/Core/Core/Slippi/SlippiNetplay.cpp
@@ -33,6 +33,8 @@
 static std::mutex pad_mutex;
 static std::mutex ack_mutex;
 
+SlippiNetplayClient* SLIPPI_NETPLAY = nullptr;
+
 // called from ---GUI--- thread
 SlippiNetplayClient::~SlippiNetplayClient()
 {
@@ -55,6 +57,8 @@ SlippiNetplayClient::~SlippiNetplayClient()
 		m_client = nullptr;
 	}
 
+	SLIPPI_NETPLAY = nullptr;
+
 	WARN_LOG(SLIPPI_ONLINE, "Netplay client cleanup complete");
 }
 
@@ -70,6 +74,7 @@ SlippiNetplayClient::SlippiNetplayClient(const std::string &address, const u16 r
 	         isDecider ? "true" : "false");
 
 	this->isDecider = isDecider;
+	SLIPPI_NETPLAY = std::move(this);
 
 	// Local address
 	ENetAddress *localAddr = nullptr;
@@ -116,6 +121,7 @@ SlippiNetplayClient::SlippiNetplayClient(const std::string &address, const u16 r
 SlippiNetplayClient::SlippiNetplayClient(bool isDecider)
 {
 	this->isDecider = isDecider;
+	SLIPPI_NETPLAY = std::move(this);
 	slippiConnectStatus = SlippiConnectStatus::NET_CONNECT_STATUS_FAILED;
 }
 
@@ -344,6 +350,7 @@ void SlippiNetplayClient::Disconnect()
 	// didn't disconnect gracefully force disconnect
 	enet_peer_reset(m_server);
 	m_server = nullptr;
+	SLIPPI_NETPLAY = nullptr;
 }
 
 void SlippiNetplayClient::SendAsync(std::unique_ptr<sf::Packet> packet)

--- a/Source/Core/Core/Slippi/SlippiNetplay.cpp
+++ b/Source/Core/Core/Slippi/SlippiNetplay.cpp
@@ -3,32 +3,33 @@
 // Refer to the license.txt file included.
 
 #include "Core/Slippi/SlippiNetplay.h"
-#include "Common/Common.h"
-#include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
 #include "Common/ENetUtil.h"
-#include "Common/MD5.h"
 #include "Common/MsgHandler.h"
 #include "Common/Timer.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
-#include "Core/HW/EXI_DeviceIPL.h"
-#include "Core/HW/SI.h"
-#include "Core/HW/SI_DeviceGCController.h"
-#include "Core/HW/Sram.h"
-#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
-#include "Core/HW/WiimoteReal/WiimoteReal.h"
-#include "Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.h"
-#include "Core/Movie.h"
-#include "InputCommon/GCAdapter.h"
 #include "VideoCommon/OnScreenDisplay.h"
 #include "VideoCommon/VideoConfig.h"
-#include <SlippiGame.h>
 #include <algorithm>
 #include <fstream>
-#include <mbedtls/md5.h>
 #include <memory>
 #include <thread>
+
+//#include "Common/MD5.h"
+//#include "Common/Common.h"
+//#include "Common/CommonPaths.h"
+//#include "Core/HW/EXI_DeviceIPL.h"
+//#include "Core/HW/SI.h"
+//#include "Core/HW/SI_DeviceGCController.h"
+//#include "Core/HW/Sram.h"
+//#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+//#include "Core/HW/WiimoteReal/WiimoteReal.h"
+//#include "Core/IPC_HLE/WII_IPC_HLE_Device_usb_bt_emu.h"
+//#include "Core/Movie.h"
+//#include "InputCommon/GCAdapter.h"
+//#include <mbedtls/md5.h>
+//#include <SlippiGame.h>
 
 static std::mutex pad_mutex;
 static std::mutex ack_mutex;

--- a/Source/Core/Core/Slippi/SlippiNetplay.h
+++ b/Source/Core/Core/Slippi/SlippiNetplay.h
@@ -192,3 +192,4 @@ class SlippiNetplayClient
 
 	u32 m_timebase_frame = 0;
 };
+extern SlippiNetplayClient* SLIPPI_NETPLAY; // singleton static pointer

--- a/Source/Core/Core/Slippi/SlippiNetplay.h
+++ b/Source/Core/Core/Slippi/SlippiNetplay.h
@@ -193,3 +193,7 @@ class SlippiNetplayClient
 	u32 m_timebase_frame = 0;
 };
 extern SlippiNetplayClient* SLIPPI_NETPLAY; // singleton static pointer
+
+static bool IsOnline(){
+    return SLIPPI_NETPLAY != nullptr;
+}

--- a/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
+++ b/Source/Core/DolphinWX/Config/GeneralConfigPane.cpp
@@ -13,6 +13,7 @@
 #include <wx/radiobox.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
+#include <Core/Slippi/SlippiNetplay.h>
 
 #include "Core/Analytics.h"
 #include "Core/ConfigManager.h"
@@ -177,6 +178,7 @@ void GeneralConfigPane::OnForceNTSCJCheckBoxChanged(wxCommandEvent& event)
 
 void GeneralConfigPane::OnThrottlerChoiceChanged(wxCommandEvent& event)
 {
+    if(IsOnline()) return;
 	if (m_throttler_choice->GetSelection() != wxNOT_FOUND)
 		SConfig::GetInstance().m_EmulationSpeed = m_throttler_choice->GetSelection() * 0.1f;
 }

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -30,6 +30,7 @@
 #include <wx/textctrl.h>
 #include <wx/thread.h>
 #include <wx/toolbar.h>
+#include <Core/Slippi/SlippiNetplay.h>
 
 #include "AudioCommon/AudioCommon.h"
 
@@ -1448,7 +1449,7 @@ void CFrame::ParseHotkeys()
 		g_Config.bDisableFog = !g_Config.bDisableFog;
 	}
 	Core::SetIsThrottlerTempDisabled(IsHotkey(HK_TOGGLE_THROTTLE, true));
-	if (IsHotkey(HK_DECREASE_EMULATION_SPEED))
+	if (IsHotkey(HK_DECREASE_EMULATION_SPEED) && !IsOnline())
 	{
 		OSDChoice = 5;
 
@@ -1462,7 +1463,7 @@ void CFrame::ParseHotkeys()
 		if (SConfig::GetInstance().m_EmulationSpeed >= 0.95f && SConfig::GetInstance().m_EmulationSpeed <= 1.05f)
 			SConfig::GetInstance().m_EmulationSpeed = 1.0f;
 	}
-	if (IsHotkey(HK_INCREASE_EMULATION_SPEED))
+	if (IsHotkey(HK_INCREASE_EMULATION_SPEED) && !IsOnline())
 	{
 		OSDChoice = 5;
 


### PR DESCRIPTION
This PR makes Netplay experience more stable in case of emulation inconsistencies.

- a singleton slippi_netplay is exposed to be available throughout the codebase