### PR TITLE
[Playback] Process paths in slippi combo files relative to the config itself

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -28,6 +28,7 @@
 #include <shellapi.h>
 #include <windows.h>
 #include <winerror.h>
+#include <Shlwapi.h>
 #else
 #include <dirent.h>
 #include <errno.h>
@@ -42,7 +43,6 @@
 #include <CoreFoundation/CFURL.h>
 #include <sys/param.h>
 #endif
-#include <Shlwapi.h>
 
 #ifndef S_ISDIR
 #define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -754,7 +754,7 @@ std::string GetAbsolutePathFromRelativePath(const std::string &path, const std::
 	}
 	else if (tempPath.back() == '/' && tempOrigin.front() == '/')
 	{
-		tempPath.erase(tempPath.size() - 1);
+		tempPath.pop_back();
 	}
 #endif
 	return tempOrigin + tempPath;
@@ -762,6 +762,7 @@ std::string GetAbsolutePathFromRelativePath(const std::string &path, const std::
 
 std::wstring s2ws(const std::string &s)
 {
+#ifdef _WIN32
 	int len;
 	int slength = (int)s.length() + 1;
 	len = MultiByteToWideChar(CP_ACP, 0, s.c_str(), slength, 0, 0);
@@ -770,6 +771,9 @@ std::wstring s2ws(const std::string &s)
 	std::wstring r(buf);
 	delete[] buf;
 	return r;
+#else
+	return NULL;
+#endif
 }
 
 std::string &GetExeDirectory()

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -42,6 +42,7 @@
 #include <CoreFoundation/CFURL.h>
 #include <sys/param.h>
 #endif
+#include <Shlwapi.h>
 
 #ifndef S_ISDIR
 #define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
@@ -722,6 +723,54 @@ std::string GetBundleDirectory()
 	return AppBundlePath;
 }
 #endif
+
+std::string GetAbsolutePathFromRelativePath(const std::string &path, const std::string &origin) {
+	std::string tempPath = path;
+	std::string tempOrigin = origin;
+#ifdef _WIN32
+	LPCWSTR winPath = s2ws(tempPath).c_str();
+	if (!PathIsRelativeW(winPath))
+	{
+		return tempPath;
+	}
+	std::replace(tempOrigin.begin(), tempOrigin.end(), '/', '\\');
+	std::replace(tempPath.begin(), tempPath.end(), '/', '\\');
+	if (tempOrigin.back() != '\\' && tempPath.front() != '\\')
+	{
+		tempOrigin.push_back('\\');
+	}
+	else if (tempOrigin.back() == '\\' && tempPath.front() == '\\')
+	{
+		tempOrigin.pop_back();
+	}
+#else
+	if (tempPath.at(0) == '/')
+	{
+		return tempPath;
+	}
+	if (tempPath.back() != '/' && tempOrigin.front() != '/')
+	{
+		tempPath.push_back('/');
+	}
+	else if (tempPath.back() == '/' && tempOrigin.front() == '/')
+	{
+		tempPath.erase(tempPath.size() - 1);
+	}
+#endif
+	return tempOrigin + tempPath;
+}
+
+std::wstring s2ws(const std::string &s)
+{
+	int len;
+	int slength = (int)s.length() + 1;
+	len = MultiByteToWideChar(CP_ACP, 0, s.c_str(), slength, 0, 0);
+	wchar_t *buf = new wchar_t[len];
+	MultiByteToWideChar(CP_ACP, 0, s.c_str(), slength, buf, len);
+	std::wstring r(buf);
+	delete[] buf;
+	return r;
+}
 
 std::string &GetExeDirectory()
 {

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -139,6 +139,12 @@ std::string CreateTempDir();
 // Get a filename that can hopefully be atomically renamed to the given path.
 std::string GetTempFilenameForAtomicWrite(const std::string& path);
 
+// Converts a relative path to an absolute path if it is a relative one
+std::string GetAbsolutePathFromRelativePath(const std::string &path, const std::string &origin);
+
+// Converts String to WString
+std::wstring s2ws(const std::string &s);
+
 // Gets a set user directory path
 // Don't call prior to setting the base user directory
 const std::string& GetUserPath(unsigned int dir_index);

--- a/Source/Core/Core/Slippi/SlippiReplayComm.cpp
+++ b/Source/Core/Core/Slippi/SlippiReplayComm.cpp
@@ -211,7 +211,7 @@ void SlippiReplayComm::loadFile()
 			{
 				json el = *it;
 				WatchSettings w = {};
-				w.path = el.value("path", "");
+				w.path = File::GetAbsolutePathFromRelativePath(el.value("path", ""), configFilePath.substr(0, configFilePath.find_last_of("\\/")));
 				w.startFrame = el.value("startFrame", Slippi::GAME_FIRST_FRAME);
 				w.endFrame = el.value("endFrame", INT_MAX);
 				w.gameStartAt = el.value("gameStartAt", "");


### PR DESCRIPTION
So that the configuration files for combos can be distributed together with the replays, the replays must be relative to the configuration file itself and not to the .exe of Dolphin (I'm doing this for clippi).

I tested it on Windows 10, with absolute and relative paths working perfectly, but I didn't test it on Unix (Linux/macOS) yet.