### PR TITLE
Assign all Netplay Ports to the hoster automatically

### DIFF
--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -600,7 +600,7 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
 			{
 				if (spectator && m_pad_map[i] == player.pid)
 				{
-					m_pad_map[i] = 1; // Assign this port for player 1
+					m_pad_map[i] = 1; // Assign this port to player 1
 				}
 			}
 		}

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -232,10 +232,7 @@ void NetPlayServer::AssignPorts(const PlayerId pid)
 	{
 		for (PadMapping &mapping : m_pad_map)
 		{
-			if (mapping == -1)
-			{
-				mapping = pid;
-			}
+			mapping = pid;
 		}
 	}
 	else // take the second port used by player 1
@@ -243,6 +240,11 @@ void NetPlayServer::AssignPorts(const PlayerId pid)
 		bool firstUsedPortDetected = false;
 		for (PadMapping &mapping : m_pad_map)
 		{
+			if (mapping == -1) // Not assigned at all? Then give me this port
+			{
+				mapping = pid;
+				break;
+			}
 			if (mapping == 1)
 			{
 				if (firstUsedPortDetected)

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -275,14 +275,36 @@ unsigned int NetPlayServer::OnConnect(ENetPeer* socket)
 
 	enet_packet_destroy(epack);
 	// try to automatically assign new user a pad
-	for (PadMapping& mapping : m_pad_map)
+	if (player.pid == 1) // Is he the first player joining the server?
 	{
-		if (mapping == -1)
+		for (PadMapping &mapping : m_pad_map)
 		{
-			mapping = player.pid;
-			break;
+			if (mapping == -1)
+			{
+				mapping = player.pid;
+			}
 		}
 	}
+	else // take the second port used by player 1
+	{
+		bool firstUsedPortDetected = false;
+		for (PadMapping &mapping : m_pad_map)
+		{
+			if (mapping == 1)
+			{
+				if (firstUsedPortDetected)
+				{
+					mapping = player.pid;
+					break;
+				}
+				else
+				{
+					firstUsedPortDetected = true;
+				}
+			}
+		}
+	}
+
 
 	// send join message to already connected clients
 	sf::Packet spac;
@@ -445,7 +467,7 @@ unsigned int NetPlayServer::OnDisconnect(Client& player)
 	{
 		if (mapping == pid)
 		{
-			mapping = -1;
+			mapping = 1; // Give the port back to player 1
 		}
 	}
 	UpdatePadMapping();

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -92,6 +92,7 @@ private:
 
 	void SendToClients(sf::Packet& packet, const PlayerId skip_pid = 0);
 	void Send(ENetPeer* socket, sf::Packet& packet);
+	void AssignPorts(const PlayerId pid);
 	unsigned int OnConnect(ENetPeer* socket);
 	unsigned int OnDisconnect(Client& player);
 	unsigned int OnData(sf::Packet& packet, Client& player);


### PR DESCRIPTION
So that people who play on other ports don't have to change their port manually all the time when being in singleplayer mode (netplay).

Playing with other people over netplay does still work though, where the new player who joins gets the second used port assigned to himself.