### PR TITLE
Fix macOS codesigning to work with replaced Resources

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -460,6 +460,7 @@ jobs:
           cd build
 
           if [[ -z "$MACOS_CERT_PASSWD" ]]; then
+            echo "Building with code signing"
             cmake -DIS_PLAYBACK=true -DMACOS_CODE_SIGNING="ON" ..
           else
             cmake -DIS_PLAYBACK=true ..
@@ -487,6 +488,7 @@ jobs:
           /usr/bin/codesign -f -s "${{ secrets.APPLE_IDENTITY_HASH }}" --deep --options runtime --entitlements Source/Core/DolphinWX/Entitlements.plist "./build/Binaries/Slippi\ Dolphin.app"
         env:
           CERTIFICATE_MACOS_APPLICATION: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
+          CERTIFICATE_MACOS_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_PASSWORD }}
       - name: "Package Playback"
         if: success()
         shell: bash

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -485,7 +485,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           chmod +x Tools/load-macos-certs-ci.sh && ./Tools/load-macos-certs-ci.sh
-          /usr/bin/codesign -f -s "${{ secrets.APPLE_IDENTITY_HASH }}" --deep --options runtime --entitlements Source/Core/DolphinWX/Entitlements.plist "./build/Binaries/Slippi\ Dolphin.app"
+          /usr/bin/codesign -f -s "${{ secrets.APPLE_IDENTITY_HASH }}" --deep --options runtime --entitlements Source/Core/DolphinWX/Entitlements.plist Slippi\ Dolphin.app
         env:
           CERTIFICATE_MACOS_APPLICATION: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
           CERTIFICATE_MACOS_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_PASSWORD }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -471,7 +471,7 @@ jobs:
       - name: "Inject Playback Resources"
         if: success()
         shell: bash
-        workig-directory: ${{ github.workspace }}
+        working-directory: ${{ github.workspace }}
         run: |
           git clone https://github.com/project-slippi/slippi-desktop-app
           cd ./build/Binaries/

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -494,8 +494,8 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}
         run: |
-          cd  ./build/Binaries
           mkdir artifact
+          cd  ./build/Binaries
           FILE_NAME=${{ env.CURR_DATE }}-${{ env.GIT_HASH }}-${{ env.GIT_TAG }}-macOS-playback.zip
           zip -r "${FILE_NAME}" Slippi\ Dolphin.app
           mv "${FILE_NAME}" ../../artifact/

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -485,7 +485,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           chmod +x Tools/load-macos-certs-ci.sh && ./Tools/load-macos-certs-ci.sh
-          /usr/bin/codesign -f -s "${{ secrets.APPLE_IDENTITY_HASH }}" --deep --options runtime --entitlements Source/Core/DolphinWX/Entitlements.plist Slippi\ Dolphin.app
+          /usr/bin/codesign -f -s "${{ secrets.APPLE_IDENTITY_HASH }}" --deep --options runtime --entitlements Source/Core/DolphinWX/Entitlements.plist build/Binaries/Slippi\ Dolphin.app
         env:
           CERTIFICATE_MACOS_APPLICATION: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
           CERTIFICATE_MACOS_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_PASSWORD }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -355,7 +355,7 @@ jobs:
           make -j7
           sudo make install
       - name: "Build Netplay (No Codesigning)"
-        if: success() && env.CERTIFICATE_MACOS_APPLICATION == null
+        if: success()
         shell: bash
         working-directory: ${{ github.workspace }}
         run: |
@@ -363,21 +363,6 @@ jobs:
           cd build
           cmake ..
           make -j7
-        env:
-          CERTIFICATE_MACOS_APPLICATION: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
-      - name: "Build & Codesign Netplay"
-        if: success() && env.CERTIFICATE_MACOS_APPLICATION != null
-        shell: bash
-        working-directory: ${{ github.workspace }}
-        run: |
-          chmod +x Tools/load-macos-certs-ci.sh && ./Tools/load-macos-certs-ci.sh
-          mkdir build
-          cd build
-          cmake -DMACOS_CODE_SIGNING="ON" -DMACOS_CODE_SIGNING_IDENTITY="${{ secrets.APPLE_IDENTITY_HASH }}" ..
-          make -j7
-        env:
-          CERTIFICATE_MACOS_APPLICATION: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
-          CERTIFICATE_MACOS_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_PASSWORD }}
       - name: "Package Netplay"
         if: success()
         shell: bash
@@ -466,41 +451,49 @@ jobs:
           ../configure
           make -j7
           sudo make install
-      - name: "Build Playback (No Codesigning)"
+      - name: "Build Playback"
         if: success() && env.CERTIFICATE_MACOS_APPLICATION == null
         shell: bash
         working-directory: ${{ github.workspace }}
         run: |
           mkdir build
           cd build
-          cmake -DIS_PLAYBACK=true ..
+
+          if [[ -z "$MACOS_CERT_PASSWD" ]]; then
+            cmake -DIS_PLAYBACK=true -DMACOS_CODE_SIGNING="ON" ..
+          else
+            cmake -DIS_PLAYBACK=true ..
+          fi
+          
           make -j7
         env:
-          CERTIFICATE_MACOS_APPLICATION: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
-      - name: "Build & Codesign Playback"
+          MACOS_CERT_PASSWD: ${{ secrets.CERTIFICATE_MACOS_PASSWORD }}
+      - name: "Inject Playback Resources"
+        if: success()
+        shell: bash
+        workig-directory: ${{ github.workspace }}
+        run: |
+          git clone https://github.com/project-slippi/slippi-desktop-app
+          cd ./build/Binaries/
+          cp -Rf ../../Data/Sys ./Slippi\ Dolphin.app/Contents/Resources
+          cp -Rf ../../slippi-desktop-app/app/dolphin-dev/overwrite/Sys ./Slippi\ Dolphin.app/Contents/Resources
+          cp -Rf ../../slippi-desktop-app/app/dolphin-dev/overwrite/User ./Slippi\ Dolphin.app/Contents/Resources 
+      - name: "Codesign Playback"
         if: success() && env.CERTIFICATE_MACOS_APPLICATION != null
         shell: bash
         working-directory: ${{ github.workspace }}
         run: |
           chmod +x Tools/load-macos-certs-ci.sh && ./Tools/load-macos-certs-ci.sh
-          mkdir build
-          cd build
-          cmake -DIS_PLAYBACK=true -DMACOS_CODE_SIGNING="ON" -DMACOS_CODE_SIGNING_IDENTITY="${{ secrets.APPLE_IDENTITY_HASH }}" ..
-          make -j7
+          /usr/bin/codesign -f -s "${{ secrets.APPLE_IDENTITY_HASH }}" --deep --options runtime --entitlements Source/Core/DolphinWX/Entitlements.plist "./build/Binaries/Slippi\ Dolphin.app"
         env:
           CERTIFICATE_MACOS_APPLICATION: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
-          CERTIFICATE_MACOS_PASSWORD: ${{ secrets.CERTIFICATE_MACOS_PASSWORD }}
       - name: "Package Playback"
         if: success()
         shell: bash
         working-directory: ${{ github.workspace }}
         run: |
+          cd  ./build/Binaries
           mkdir artifact
-          git clone https://github.com/project-slippi/slippi-desktop-app
-          cd ./build/Binaries/
-          cp -Rf ../../Data/Sys ./Slippi\ Dolphin.app/Contents/Resources
-          cp -Rf ../../slippi-desktop-app/app/dolphin-dev/overwrite/Sys ./Slippi\ Dolphin.app/Contents/Resources
-          cp -Rf ../../slippi-desktop-app/app/dolphin-dev/overwrite/User ./Slippi\ Dolphin.app/Contents/Resources
           FILE_NAME=${{ env.CURR_DATE }}-${{ env.GIT_HASH }}-${{ env.GIT_TAG }}-macOS-playback.zip
           zip -r "${FILE_NAME}" Slippi\ Dolphin.app
           mv "${FILE_NAME}" ../../artifact/

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -212,9 +212,10 @@ if(wxWidgets_FOUND)
 		endif()
 
 		if(MACOS_CODE_SIGNING)
-			add_custom_command(TARGET ${DOLPHIN_EXE}
-				POST_BUILD COMMAND
-				/usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options runtime --entitlements ${CMAKE_SOURCE_DIR}/Source/Core/DolphinWX/Entitlements.plist "${BUNDLE_PATH_NO_QUOTES}")
+            # Disable this as we need to codesign AFTER resources replacement.
+            #add_custom_command(TARGET ${DOLPHIN_EXE}
+            #	POST_BUILD COMMAND
+            #	/usr/bin/codesign -f -s "${MACOS_CODE_SIGNING_IDENTITY}" --deep --options runtime --entitlements ${CMAKE_SOURCE_DIR}/Source/Core/DolphinWX/Entitlements.plist "${BUNDLE_PATH_NO_QUOTES}")
 		endif()
 	else()
 		install(TARGETS ${DOLPHIN_EXE} RUNTIME DESTINATION ${bindir})


### PR DESCRIPTION
The previous merge didn't take into account replacing resources post-CMake build, which causes some issues to show up with resources that weren't part of the original signature being injected.

This issue is working around that, will probably need to tweak like the last one.