### PR TITLE
Avoid MAP_JIT on High Sierra

### DIFF
--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -38,7 +38,7 @@ namespace Common
 #include <unistd.h>
 static uintptr_t RoundPage(uintptr_t addr)
 {
-	uintptr_t mask = getpagesize() - 1;
+    uintptr_t mask = getpagesize() - 1;
 	return (addr + mask) & ~mask;
 }
 #endif
@@ -47,20 +47,20 @@ static uintptr_t RoundPage(uintptr_t addr)
 // On High Sierra, passing MAP_JIT seems to cause weird issues - the hardened runtime only exists
 // from Mojave (10.14) onwards, so there's some clash happening in 10.13. Thus, we just need to branch
 // here for that one OS (18 is the kernel for Mojave)... and this should be removed at some point. 
-static int determine_macos_jit_flag()
+static inline int determine_macos_jit_flag()
 {
-    static int jit_flag = -1;
+	static int jit_flag = -1;
 
-    if (jit_flag == -1)
-    {
-        struct utsname name;
-        uname(&name);
-        
-        // Kernel version 18 = Mojave
-        jit_flag = (atoi(name.release) >= 18) ? MAP_JIT : 0;
-    }
+	if (jit_flag == -1)
+	{
+		struct utsname name;
+		uname(&name);
 
-    return jit_flag;
+		// Kernel version 18 = Mojave
+		jit_flag = (atoi(name.release) >= 18) ? MAP_JIT : 0;
+	}
+
+	return jit_flag;
 }
 #endif
 
@@ -84,9 +84,9 @@ void* AllocateExecutableMemory(size_t size, bool low)
 		map_hint = (char*)RoundPage(512 * 1024 * 1024); /* 0.5 GB rounded up to the next page */
 #endif
 
-	int flags = MAP_ANON | MAP_PRIVATE;    
+	int flags = MAP_ANON | MAP_PRIVATE;
 #ifdef __APPLE__
-    flags |= determine_macos_jit_flag();
+	flags |= determine_macos_jit_flag();
 #endif
 
 	void* ptr = mmap(map_hint, size, PROT_READ | PROT_WRITE | PROT_EXEC, flags

--- a/Source/Core/Common/MemoryUtil.cpp
+++ b/Source/Core/Common/MemoryUtil.cpp
@@ -38,7 +38,7 @@ namespace Common
 #include <unistd.h>
 static uintptr_t RoundPage(uintptr_t addr)
 {
-    uintptr_t mask = getpagesize() - 1;
+	uintptr_t mask = getpagesize() - 1;
 	return (addr + mask) & ~mask;
 }
 #endif


### PR DESCRIPTION
I'm fairly positive this is what's causing crashes in the Desktop app under High Sierra, as it breaks in the emulation thread during JIT. My best guess is that this flag messes up the mmap flags under High Sierra, since Mojave and onwards are the only ones that even get the hardened runtime.