### PR TITLE
Fix for blocking input bugs

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -2190,6 +2190,7 @@ void CEXISlippi::DMAWrite(u32 _uAddr, u32 _uSize)
 	if (byte == CMD_MENU_FRAME)
 	{
 		m_slippiserver->write(&memPtr[0], _uSize);
+		g_needInputForFrame = true;
 	}
 
 	INFO_LOG(EXPANSIONINTERFACE, "EXI SLIPPI DMAWrite: addr: 0x%08x size: %d, bufLoc:[%02x %02x %02x %02x %02x]",

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
@@ -180,6 +180,10 @@ void PipeDevice::UpdateInput()
     // then dequeue a command off the front of m_buf and parse it.
     char buf[32];
     s32 bytes_read = readFromPipe(m_fd, buf, sizeof buf);
+    if (bytes_read == 0) {
+      // Pipe died, so just quit out
+      return;
+    }
     while (bytes_read > 0)
     {
       m_buf.append(buf, bytes_read);


### PR DESCRIPTION
 - Infinite loop on broken pipe (quits now when pipe is broken)
 - Input not blocking on menu frames