### PR TITLE
Fix sysdata path for nonportable install

### DIFF
--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -37,7 +37,7 @@
 #elif defined ANDROID
 	#define SYSDATA_DIR "/sdcard/dolphin-emu"
 #else
-	#define SYSDATA_DIR "Sys"
+	#define SYSDATA_DIR DATA_DIR "sys"
 #endif
 
 // Dirs in both User and Sys


### PR DESCRIPTION
The AppImage patch overwrote the sysdata path used for nonportable installations too, so this brings it back in line with upstream:
https://github.com/dolphin-emu/dolphin/blob/5abae61a8c7e0e4ac03bb8d3031793037e87fdd3/Source/Core/Common/FileUtil.cpp#L780-L784
This codepath is only used for non-portable linux, so it should not affect the portable installations used for CI and distributed binaries.