### PR TITLE
Send empty pad buffers when game begins to avoid underrun

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -1589,6 +1589,17 @@ void CEXISlippi::handleSendInputs(u8 *payload)
 	int32_t frame = payload[0] << 24 | payload[1] << 16 | payload[2] << 8 | payload[3];
 	u8 delay = payload[4];
 
+	// On the first frame sent, we need to queue up empty dummy pads for as many
+	//	frames as we have delay
+	if (frame == 1)
+	{
+		for (int i = 1; i <= delay; i++)
+		{
+			auto empty = std::make_unique<SlippiPad>(i);
+			slippi_netplay->SendSlippiPad(std::move(empty));
+		}
+	}
+
 	auto pad = std::make_unique<SlippiPad>(frame + delay, &payload[5]);
 
 	slippi_netplay->SendSlippiPad(std::move(pad));

--- a/Source/Core/Core/Slippi/SlippiNetplay.cpp
+++ b/Source/Core/Core/Slippi/SlippiNetplay.cpp
@@ -181,12 +181,12 @@ unsigned int SlippiNetplayClient::OnData(sf::Packet &packet)
 			int32_t headFrame = remotePadQueue.empty() ? 0 : remotePadQueue.front()->frame;
 			int inputsToCopy = frame - headFrame;
 
-			//// Check that the packet actually contains the data it claims to
-			// if((5 + inputsToCopy * SLIPPI_PAD_DATA_SIZE) > (int)packet.getDataSize())
-			//{
-			//	ERROR_LOG(SLIPPI_ONLINE, "Netplay packet too small to read pad buffer");
-			//	break;
-			//}
+			// Check that the packet actually contains the data it claims to
+			if((5 + inputsToCopy * SLIPPI_PAD_DATA_SIZE) > (int)packet.getDataSize())
+			{
+				ERROR_LOG(SLIPPI_ONLINE, "Netplay packet too small to read pad buffer");
+				break;
+			}
 
 			for (int i = inputsToCopy - 1; i >= 0; i--)
 			{


### PR DESCRIPTION
Reinstate bounds checking on incoming packet. It was commented out because it was causing disconnects. Bring it back.

Also add extra empty pad sends at the start of a game to make up for the difference in buffer. Pads are otherwise sent starting at 1+buffer amount, but the receiver expects a different amount. So to recap...

Alice (2 frame-delay) connects to Bob.
Sends pads: 3, 4, 5, 6...

But when Bob receives the first packet (labeled as frame 3) Bob expects there to be 3 pads in the packet. Bob then naively keeps reading past the pad buffer for the data. Since the pad buffer is on the heap, it can reach out of bounds and segfault if you're unlucky. 