### PR TITLE
Add command line option to show current app version

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -109,6 +109,9 @@ bool DolphinApp::OnInit()
 	std::lock_guard<std::mutex> lk(s_init_mutex);
 	if (!wxApp::OnInit())
 		return false;
+	if (m_show_version)
+		std::cout << scm_slippi_semver_str << std::endl;
+		return false;
 	wxLog::SetLogLevel(0);
 	Bind(wxEVT_QUERY_END_SESSION, &DolphinApp::OnEndSession, this);
 	Bind(wxEVT_END_SESSION, &DolphinApp::OnEndSession, this);
@@ -250,6 +253,8 @@ void DolphinApp::OnInitCmdLine(wxCmdLineParser &parser)
 {
 	static const wxCmdLineEntryDesc desc[] = {
 	    {wxCMD_LINE_SWITCH, "h", "help", "Show this help message", wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP},
+	    {wxCMD_LINE_SWITCH, "ve", "version", "Show the current app version", wxCMD_LINE_VAL_NONE,
+	     wxCMD_LINE_PARAM_OPTIONAL},
 	    {wxCMD_LINE_SWITCH, "d", "debugger", "Opens the debugger", wxCMD_LINE_VAL_NONE, wxCMD_LINE_PARAM_OPTIONAL},
 	    {wxCMD_LINE_SWITCH, "l", "logger", "Opens the logger", wxCMD_LINE_VAL_NONE, wxCMD_LINE_PARAM_OPTIONAL},
 	    {wxCMD_LINE_OPTION, "e", "exec", "Loads the specified file (ELF, DOL, GCM, ISO, TGC, WBFS, CISO, GCZ, WAD)",
@@ -328,6 +333,7 @@ bool DolphinApp::OnCmdLineParsed(wxCmdLineParser &parser)
 
 	m_use_debugger = parser.Found("debugger");
 	m_use_logger = parser.Found("logger");
+	m_show_version = parser.Found("version");
 	m_batch_mode = parser.Found("batch");
 	m_confirm_stop = parser.Found("confirm", &m_confirm_setting);
 	m_select_video_backend = parser.Found("video_backend", &m_video_backend_name);

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -110,8 +110,10 @@ bool DolphinApp::OnInit()
 	if (!wxApp::OnInit())
 		return false;
 	if (m_show_version)
+	{
 		std::cout << scm_slippi_semver_str << std::endl;
 		return false;
+	}
 	wxLog::SetLogLevel(0);
 	Bind(wxEVT_QUERY_END_SESSION, &DolphinApp::OnEndSession, this);
 	Bind(wxEVT_END_SESSION, &DolphinApp::OnEndSession, this);

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -255,7 +255,7 @@ void DolphinApp::OnInitCmdLine(wxCmdLineParser &parser)
 {
 	static const wxCmdLineEntryDesc desc[] = {
 	    {wxCMD_LINE_SWITCH, "h", "help", "Show this help message", wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP},
-	    {wxCMD_LINE_SWITCH, "ve", "version", "Show the current app version", wxCMD_LINE_VAL_NONE,
+	    {wxCMD_LINE_SWITCH, nullptr, "version", "Show the current app version", wxCMD_LINE_VAL_NONE,
 	     wxCMD_LINE_PARAM_OPTIONAL},
 	    {wxCMD_LINE_SWITCH, "d", "debugger", "Opens the debugger", wxCMD_LINE_VAL_NONE, wxCMD_LINE_PARAM_OPTIONAL},
 	    {wxCMD_LINE_SWITCH, "l", "logger", "Opens the logger", wxCMD_LINE_VAL_NONE, wxCMD_LINE_PARAM_OPTIONAL},

--- a/Source/Core/DolphinWX/Main.h
+++ b/Source/Core/DolphinWX/Main.h
@@ -46,6 +46,7 @@ private:
 	bool m_play_movie = false;
 	bool m_use_debugger = false;
 	bool m_use_logger = false;
+	bool m_show_version = false;
 	bool m_select_video_backend = false;
 	bool m_select_slippi_input = false;
 	bool m_select_output_directory = false;


### PR DESCRIPTION
I have no idea what I'm doing.

But this lets people specify the `--version` flag to show the app version. For the life of me I can't figure out why I can't see stdout when running from the command line, but I checked when spawning the process via node it prints the version correctly.

Also ideally the `-v` flag would show the version since that's basically the universally accepted command, but alas it's already taken by the video backend flag.