### PR TITLE
Remove explicit wxWidgets `UnInit()` call.

### DIFF
--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -617,7 +617,11 @@ void CFrame::OnClose(wxCloseEvent &event)
 		m_LogWindow->RemoveAllListeners();
 
 	// Uninit
-	m_Mgr->UnInit();
+    // As of wxWidgets 3.1.4, this is called automatically - and calling
+    // it here can lead to a doubling of shutdown conditions, which leads
+    // to a "crash" on close on some systems.
+    //
+	// m_Mgr->UnInit();
 }
 
 // Post events


### PR DESCRIPTION
Removing this due to a change in wxWidgets 3.1.4, where `UnInit()` is actually called transparently on destruction. Explicitly calling it is leading to a crash-on-close on some macOS installations.

The relevant wxWidgets commit can be found here: https://github.com/wxWidgets/wxWidgets/commit/4dd009136c703b41bb961cc4bd834444f8aa62d3