### PR TITLE
macOS: disallow run from dmg volume

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -177,6 +177,13 @@ bool DolphinApp::OnInit()
 	wxImage::AddHandler(new wxPNGHandler);
 
 #ifdef __APPLE__
+    // Here we check if the app is running in a quarantined state. A quarantined flag is
+    // applied by macOS GateKeeper if the app is unsigned, downloaded from the internet, or
+    // some other flags that can't possibly be listed here.
+    //
+    // If we detect that it's running quarantined, we tell the user to explicitly move it to the
+    // Applications folder, otherwise the app will fail in subtle fails due to be mounted as a translocated
+    // binary and being "read-only".
 	typedef Boolean (*SecTranslocateIsTranslocatedURL)(CFURLRef path, bool *isTranslocated, CFErrorRef *error);
 	typedef CFURLRef (*SecTranslocateCreateOriginalPathForURL)(CFURLRef translocatedPath, CFErrorRef * error);
 
@@ -222,14 +229,38 @@ bool DolphinApp::OnInit()
 				}
 
 				wxMessageBox("This app is quarantined! Move it to your Applications folder and reopen it.\nAsk in the "
-				             "Discord (#macos-support) for further help.",
-				             "An error occured", wxOK | wxCENTRE | wxICON_WARNING);
+				             "Discord (#mac-support) for further help.",
+				             "Slippi is Quarantined.", wxOK | wxCENTRE | wxICON_WARNING);
 				exit(EXIT_SUCCESS);
 			}
 		}
 
 		dlclose(security_framework);
 	}
+
+    // Here, we check to see if the user is running the app from the mounted installer (DMG) volume. If so,
+    // we guide them to make sure the app is installed and running correctly. Running from the DMG volume exhibits
+    // similar characteristics to running the app as a quarantined application re: read-only filesystem issues.
+    CFBundleRef mainBundle = CFBundleGetMainBundle();
+    CFURLRef bundleURL = CFBundleCopyBundleURL(mainBundle);
+    CFStringRef url;
+
+    if(CFURLCopyResourcePropertyForKey(bundleURL, kCFURLVolumeNameKey, &url, NULL)) {
+        const char *volume = CFStringGetCStringPtr(url, kCFStringEncodingUTF8);
+        fprintf(stderr, "Volume: %s\n", volume);
+
+        if(strcmp(volume, "Slippi Dolphin Installer") == 0) {
+		    wxMessageBox("Slippi needs to be in your Applications folder to run properly, but you're trying to "
+                    "run it from the Installer. Make sure you've dragged the app to the Applications folder, and "
+                    "then start the app from there.",
+				    "Slippi must be in Applications.", wxOK | wxCENTRE | wxICON_WARNING);
+			exit(EXIT_SUCCESS);
+        }
+    }
+
+    CFRelease(url);
+    CFRelease(bundleURL);
+    CFRelease(mainBundle);
 #endif
 
 	// We have to copy the size and position out of SConfig now because CFrame's OnMove

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -238,29 +238,29 @@ bool DolphinApp::OnInit()
 		dlclose(security_framework);
 	}
 
-    // Here, we check to see if the user is running the app from the mounted installer (DMG) volume. If so,
-    // we guide them to make sure the app is installed and running correctly. Running from the DMG volume exhibits
-    // similar characteristics to running the app as a quarantined application re: read-only filesystem issues.
-    CFBundleRef mainBundle = CFBundleGetMainBundle();
-    CFURLRef bundleURL = CFBundleCopyBundleURL(mainBundle);
-    CFStringRef url;
+	// Here, we check to see if the user is running the app from the mounted installer (DMG) volume. If so,
+	// we guide them to make sure the app is installed and running correctly. Running from the DMG volume exhibits
+	// similar characteristics to running the app as a quarantined application re: read-only filesystem issues.
+	CFBundleRef mainBundle = CFBundleGetMainBundle();
+	CFURLRef bundleURL = CFBundleCopyBundleURL(mainBundle);
+	CFStringRef url;
 
-    if(CFURLCopyResourcePropertyForKey(bundleURL, kCFURLVolumeNameKey, &url, NULL)) {
-        const char *volume = CFStringGetCStringPtr(url, kCFStringEncodingUTF8);
-        fprintf(stderr, "Volume: %s\n", volume);
+	if(CFURLCopyResourcePropertyForKey(bundleURL, kCFURLVolumeNameKey, &url, NULL)) {
+		const char *volume = CFStringGetCStringPtr(url, kCFStringEncodingUTF8);
+		// fprintf(stderr, "Volume: %s\n", volume);
 
-        if(strcmp(volume, "Slippi Dolphin Installer") == 0) {
-		    wxMessageBox("Slippi needs to be in your Applications folder to run properly, but you're trying to "
-                    "run it from the Installer. Make sure you've dragged the app to the Applications folder, and "
-                    "then start the app from there.",
-				    "Slippi must be in Applications.", wxOK | wxCENTRE | wxICON_WARNING);
+		if(strcmp(volume, "Slippi Dolphin Installer") == 0) {
+			wxMessageBox("Slippi needs to be in your Applications folder to run properly, but you're trying to "
+				"run it from the Installer. Make sure you've dragged the app to the Applications folder, and "
+				"then start the app from there.",
+				"Slippi must be in Applications.", wxOK | wxCENTRE | wxICON_WARNING);
 			exit(EXIT_SUCCESS);
-        }
-    }
+		}
+	}
 
-    CFRelease(url);
-    CFRelease(bundleURL);
-    CFRelease(mainBundle);
+	CFRelease(url);
+	CFRelease(bundleURL);
+	CFRelease(mainBundle);
 #endif
 
 	// We have to copy the size and position out of SConfig now because CFrame's OnMove


### PR DESCRIPTION
Check the volume that the user is running Slippi from. If they're found to be running from the mounted Installer volume (which we know the name of), we throw up a message explaining why it won't work and what they should do instead.