### PR TITLE
CI incorrect path for macOS script.

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -281,7 +281,7 @@ jobs:
           CERTIFICATE_MACOS_APPLICATION: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
         run: |
           rm build/Binaries/traversal_server
-          chmod +x Tools/create-dmg.sh 
+          chmod +x Tools/create-dmg/run.sh 
           ./Tools/create-dmg/run.sh --no-internet-enable \
             --volname "Slippi Dolphin Installer" \
             --volicon "Data/slippi_dmg_icon.icns" \


### PR DESCRIPTION
CI will be the death of me. Inability to test or verify gets me every time. -_-;

`chmod` pointing to the wrong file, needs to point to `Tools/create-dmg/run.sh`.