### PR TITLE
Avoid CFStringGetCStringPtr as it can return NULL.

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -177,13 +177,13 @@ bool DolphinApp::OnInit()
 	wxImage::AddHandler(new wxPNGHandler);
 
 #ifdef __APPLE__
-    // Here we check if the app is running in a quarantined state. A quarantined flag is
-    // applied by macOS GateKeeper if the app is unsigned, downloaded from the internet, or
-    // some other flags that can't possibly be listed here.
-    //
-    // If we detect that it's running quarantined, we tell the user to explicitly move it to the
-    // Applications folder, otherwise the app will fail in subtle fails due to be mounted as a translocated
-    // binary and being "read-only".
+	// Here we check if the app is running in a quarantined state. A quarantined flag is
+	// applied by macOS GateKeeper if the app is unsigned, downloaded from the internet, or
+	// some other flags that can't possibly be listed here.
+	//
+	// If we detect that it's running quarantined, we tell the user to explicitly move it to the
+	// Applications folder, otherwise the app will fail in subtle fails due to be mounted as a translocated
+	// binary and being "read-only".
 	typedef Boolean (*SecTranslocateIsTranslocatedURL)(CFURLRef path, bool *isTranslocated, CFErrorRef *error);
 	typedef CFURLRef (*SecTranslocateCreateOriginalPathForURL)(CFURLRef translocatedPath, CFErrorRef * error);
 
@@ -246,19 +246,31 @@ bool DolphinApp::OnInit()
 	CFStringRef url;
 
 	if(CFURLCopyResourcePropertyForKey(bundleURL, kCFURLVolumeNameKey, &url, NULL)) {
-		const char *volume = CFStringGetCStringPtr(url, kCFStringEncodingUTF8);
-		// fprintf(stderr, "Volume: %s\n", volume);
+		// If you look at this and wonder why we can't just call CFStringGetCStringPtr, the
+		// reason is that it can technically return NULL - and actually does, in this case... 
+		// but on Mojave.
+		//
+		// Go figure.
+		//
+		// If we can't determine the volume name, then we'll just silently move on and deal
+		// with it as a support request I guess.
+		CFIndex maxSize = CFStringGetMaximumSizeForEncoding(CFStringGetLength(url), kCFStringEncodingUTF8);
+		char volume_name [maxSize + 1];
+		if(CFStringGetCString(url, volume_name, maxSize + 1, kCFStringEncodingUTF8)) {
+			//fprintf(stderr, "Volume: %s\n", volume_name);
 
-		if(strcmp(volume, "Slippi Dolphin Installer") == 0) {
-			wxMessageBox("Slippi needs to be in your Applications folder to run properly, but you're trying to "
-				"run it from the Installer. Make sure you've dragged the app to the Applications folder, and "
-				"then start the app from there.",
-				"Slippi must be in Applications.", wxOK | wxCENTRE | wxICON_WARNING);
-			exit(EXIT_SUCCESS);
-		}
+			if(strcmp(volume_name, "Slippi Dolphin Installer") == 0) {
+				wxMessageBox("Slippi needs to be in your Applications folder to run properly, but you're trying to "
+					"run it from the Installer. Make sure you've dragged the app to the Applications folder, and "
+					"then start the app from there.",
+					"Slippi must be in Applications.", wxOK | wxCENTRE | wxICON_WARNING);
+				exit(EXIT_SUCCESS);
+			}
+ 		}
+
+		CFRelease(url);
 	}
 
-	CFRelease(url);
 	CFRelease(bundleURL);
 	CFRelease(mainBundle);
 #endif


### PR DESCRIPTION
...on Mojave. Go figure. Change this block to be a bit safer/fail-safe-y.

I have a sneaking suspicion that this happens in cases where the "default" Volume name has been changed, but don't have time to verify it. This was tested across my Mac setups, as well as a Mojave setup, correctly detecting volume names in each case. It should also silently bail now if it can't do it, for whatever reason.