### PR TITLE
Revert behavior of wxStrToStr

### DIFF
--- a/Source/Core/DolphinWX/WxUtils.cpp
+++ b/Source/Core/DolphinWX/WxUtils.cpp
@@ -523,7 +523,7 @@ wxImage ScaleImage(wxImage image, double source_scale_factor, double content_sca
 
 std::string WxStrToStr(const wxString& str)
 {
-	return str.ToStdString();
+	return str.ToUTF8().data();
 }
 
 wxString StrToWxStr(const std::string& str)


### PR DESCRIPTION
Looking at this, I think it was changed when getting Externals/wxWidgets
updated to 3.1.4, but this particular method didn't need to stay
changed. For Windows users who run in different locales, I suspect it's causing
issues with folder paths that contain special characters.

Reverting the behavior does not break the build and my initial testing
shows no issues. I believe this went undetected during testing due to
the aforementioned locale issue, with none of us actually being in a different
locale.