### PR TITLE
Logging fix.

### DIFF
--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -73,18 +73,6 @@ static const char LOG_LEVEL_TO_CHAR[7] = "-NEWID";
 
 }  // namespace
 
-// Short File code taken from https://blog.galowicz.de/2016/02/20/short_file_macro/
-static constexpr const char *past_last_slash(const char *str, const char * last_slash)
-{
-	return *str == '\0' ? last_slash
-	                    : *str == '/' || *str == '\\' ? past_last_slash(str + 1, str + 1) : past_last_slash(str + 1, last_slash);
-}
-
-static constexpr const char *past_last_slash(const char * str)
-{
-	return past_last_slash(str, str);
-}
-
 void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char* file, int line,
 	const char* fmt, ...)
 #ifdef __GNUC__
@@ -104,7 +92,7 @@ void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const char*
 #define GENERIC_LOG(t, v, ...)                                                                     \
   {                                                                                                \
     if (v <= MAX_LOGLEVEL)                                                                         \
-      GenericLog(v, t, past_last_slash(__FILE__), __LINE__, __VA_ARGS__);                                           \
+      GenericLog(v, t, __FILE__, __LINE__, __VA_ARGS__);                                           \
   }
 
 #define ERROR_LOG(t, ...)                                                                          \

--- a/Source/Core/Common/Logging/LogManager.cpp
+++ b/Source/Core/Common/Logging/LogManager.cpp
@@ -2,8 +2,10 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <cstdarg>
 #include <cstring>
+#include <locale>
 #include <mutex>
 #include <ostream>
 #include <set>
@@ -32,8 +34,18 @@ LogManager* LogManager::m_logManager = nullptr;
 
 static size_t DeterminePathCutOffPoint()
 {
-	constexpr const char* pattern = DIR_SEP "Source" DIR_SEP "Core" DIR_SEP;
-	size_t pos = std::string(__FILE__).find(pattern);
+	constexpr const char* pattern = "/source/core/";
+#ifdef _WIN32
+	constexpr const char* pattern2 = "\\source\\core\\";
+#endif
+	std::string path = __FILE__;
+	std::transform(path.begin(), path.end(), path.begin(),
+		[](char c) { return std::tolower(c, std::locale::classic()); });
+	size_t pos = path.find(pattern);
+#ifdef _WIN32
+	if (pos == std::string::npos)
+		pos = path.find(pattern2);
+#endif
 	if (pos != std::string::npos)
 		return pos + strlen(pattern);
 	return 0;


### PR DESCRIPTION
This reverts commit b9b0416a5372f3469816045697afce93194ca1eb.

LogManager already contains code to remove parts of the file path,
combined with b9b0416a5 this results in path_to_print in LogManager::Log
often pointing past the end of "file" string resulting in botched logs.

Either b9b0416a5 needs to be reverted or m_path_cutoff_point addition
removed from LogManager::Log.