### PR TITLE
Prevent sigabort when parsing invalid json

### DIFF
--- a/Source/Core/Core/Slippi/SlippiSpectate.cpp
+++ b/Source/Core/Core/Slippi/SlippiSpectate.cpp
@@ -193,7 +193,7 @@ void SlippiSpectateServer::handleMessage(u8 *buffer, u32 length, u16 peer_id)
 {
 	// Unpack the message
 	std::string message((char *)buffer, length);
-	json json_message = json::parse(message);
+	json json_message = json::parse(message, nullptr, false);
 	if (!json_message.is_discarded() && (json_message.find("type") != json_message.end()))
 	{
 		// Check what type of message this is


### PR DESCRIPTION
 - Optional parse() arg to not throw exceptions