### PR TITLE
macOS: Persist user files to AppSupport directory

### DIFF
--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -721,6 +721,18 @@ std::string GetBundleDirectory()
 
 	return AppBundlePath;
 }
+
+std::string GetApplicationSupportDirectory()
+{
+	std::string dir = File::GetHomeDirectory() + "/Library/Application Support/com.project-slippi.dolphin";
+
+	if(!CreateDir(dir))
+	{
+		ERROR_LOG(COMMON, "Unable to create Application Support directory: %s:", dir.c_str());
+    	}
+
+	return dir;
+}
 #endif
 
 std::string &GetExeDirectory()
@@ -798,7 +810,7 @@ std::string GetSysDirectory()
 std::string GetSlippiUserJSONPath()
 {
 #if defined(__APPLE__)
-	std::string userFilePath = File::GetBundleDirectory() + "/Contents/Resources" + DIR_SEP + "user.json";
+    std::string userFilePath = File::GetApplicationSupportDirectory() + "/Slippi/user.json";
 #elif defined(_WIN32)
 	std::string userFilePath = File::GetExeDirectory() + DIR_SEP + "user.json";
 #else

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -159,6 +159,7 @@ std::string GetSysDirectory();
 
 #ifdef __APPLE__
 std::string GetBundleDirectory();
+std::string GetApplicationSupportDirectory();
 #endif
 
 std::string& GetExeDirectory();

--- a/Source/Core/Core/Slippi/SlippiDirectCodes.cpp
+++ b/Source/Core/Core/Slippi/SlippiDirectCodes.cpp
@@ -177,7 +177,7 @@ std::string SlippiDirectCodes::getCodesFilePath()
 
 	// TODO: Move to User dir
 #if defined(__APPLE__)
-	std::string directCodesPath = File::GetBundleDirectory() + "/Contents/Resources/User/Slippi/" + m_fileName;
+	std::string directCodesPath = File::GetApplicationSupportDirectory() + "/Slippi/" + m_fileName;
 #elif defined(_WIN32)
 	std::string directCodesPath = File::GetExeDirectory() + "/User/Slippi/" + m_fileName;
 #else

--- a/Source/Core/Core/Slippi/SlippiUser.cpp
+++ b/Source/Core/Core/Slippi/SlippiUser.cpp
@@ -156,11 +156,11 @@ bool SlippiUser::AttemptLogin()
 void SlippiUser::OpenLogInPage()
 {
 #ifdef _WIN32
-	if (!SlippiAuthWebView::IsAvailable())
-	{
+	// Uncomment this if Windows is in a position to try the login flow.
+	//if (!SlippiAuthWebView::IsAvailable())
+	//{
 		std::string url = "https://slippi.gg/online/enable";
 		std::string path = File::GetSlippiUserJSONPath();
-		;
 
 		// On windows, sometimes the path can have backslashes and slashes mixed, convert all to backslashes
 		path = ReplaceAll(path, "\\", "\\");
@@ -172,27 +172,7 @@ void SlippiUser::OpenLogInPage()
 		std::string command = "explorer \"" + fullUrl + "\"";
 		RunSystemCommand(command);
 		return;
-	}
-
-	// Uncomment this if Windows is in a position to try the login flow.
-	//
-	// if (!SlippiAuthWebView::IsAvailable())
-	// {
-	std::string url = "https://slippi.gg/online/enable";
-	std::string path = File::GetSlippiUserJSONPath();
-	;
-
-	// On windows, sometimes the path can have backslashes and slashes mixed, convert all to backslashes
-	path = ReplaceAll(path, "\\", "\\");
-	path = ReplaceAll(path, "/", "\\");
-
-	std::string fullUrl = url + "?path=" + path;
-	INFO_LOG(SLIPPI_ONLINE, "[User] Login at path: %s", fullUrl.c_str());
-
-	std::string command = "explorer \"" + fullUrl + "\"";
-	RunSystemCommand(command);
-	return;
-	// }
+	//}
 #endif
 
 	// macOS and Linux have stable WebView components that we can use to


### PR DESCRIPTION
- Adds a `GetApplicationSupportDirectory()` method to FileUtils.
- Updates the Slippi `user.json` path method to point to the Application Support Directory.
- Updates the codes path method to point to the Application Support
  directory.
- Cleans up duplicated logic in the webview opening block; not sure why
  that was like that.

Tested on macOS Catalina 10.15.7, but should test a CI build that's
signed to be completely sure.