### PR TITLE
Fix broken names in chat when they have commas.

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -2638,12 +2638,14 @@ std::vector<u8> CEXISlippi::loadPremadeText(u8 *payload)
 
 		//WARN_LOG(SLIPPI, "SLIPPI premade text param: 0x%x", payload[1]);
 		u8 paramId = payload[1];
-		// Clear out any non supported characters (TODO: do this in a loop with more unsupported characters)
-		playerName = ReplaceAll(playerName.c_str(), "`", "");
-		playerName = ReplaceAll(playerName.c_str(), "\\", "");
 
-		playerName = ReplaceAll(playerName.c_str(), "<", "\\"); // Replace any opening tags with "\" for now
-		playerName = ReplaceAll(playerName.c_str(), ">", "`"); // Replace any closing tags with "`" for now
+		for (auto it = spt.unsupportedStringMap.begin(); it != spt.unsupportedStringMap.end(); it++)
+		{
+			playerName = ReplaceAll(playerName.c_str(), it->second, ""); // Remove unsupported chars
+			playerName = ReplaceAll(playerName.c_str(), it->first, it->second); // Remap delimiters for premade text
+		}
+
+		// Replaces spaces with premade text space
 		playerName = ReplaceAll(playerName.c_str(), " ", "<S>");
 
 		if (paramId == SlippiPremadeText::CHAT_MSG_CHAT_DISABLED)

--- a/Source/Core/Core/Slippi/SlippiPremadeText.h
+++ b/Source/Core/Core/Slippi/SlippiPremadeText.h
@@ -79,6 +79,14 @@ class SlippiPremadeText
 	    {SPT_CHAT_DISABLED, "<LEFT><KERN><COLOR, 0, 178, 2>%s<S><COLOR, 255, 255, 255>has<S>chat<S>disabled<S><END>"},
 	};
 
+	// This is just a map of delimiters and temporary replacements to remap them before the name is converted
+	// to Slippi Premade Text format
+	unordered_map<string, string> unsupportedStringMap = {
+	    {"<", "\\"},
+	    {">", "`"},
+	    {",", "Ç"},
+	};
+
 	// TODO: use va_list to handle any no. or args
 	string GetPremadeTextString(u8 textId) { return premadeTexts[textId]; }
 
@@ -189,8 +197,13 @@ class SlippiPremadeText
 						int chr = utfMatch[c];
 						// We are manually replacing "<" for "\" and ">" for "`" because I don't want to handle vargs
 						// and we need to prevent "format injection" lol...
-						chr = chr == '\\' ? '<' : chr == '`' ? '>' : chr;
-						// DEBUG_LOG(SLIPPI, "CHAR 0x%x", chr);
+						for (auto it = unsupportedStringMap.begin(); it != unsupportedStringMap.end(); it++)
+						{
+							if (it->second.find(chr) != std::string::npos || (chr == U'Ç' && it->first[0] == ','))
+							{ // Need to figure out how to find extended ascii chars (Ç)
+								chr = it->first[0];
+							}
+						}
 
 						// Yup, fuck strchr and cpp too, I'm not in the mood to spend 4 more hours researching how to
 						// get Japanese characters properly working with a map, so I put everything on an int array in

--- a/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/CommandBufferManager.cpp
@@ -264,7 +264,7 @@ void CommandBufferManager::SubmitCommandBuffer(bool submit_on_worker_thread,
 		if (res != VK_SUCCESS)
 		{
 			LOG_VULKAN_ERROR(res, "vkEndCommandBuffer failed: ");
-			PanicAlert("Failed to end command buffer");
+//			PanicAlert("Failed to end command buffer");
 		}
 	}
 
@@ -335,7 +335,7 @@ void CommandBufferManager::SubmitCommandBuffer(size_t index, VkSemaphore wait_se
 	if (res != VK_SUCCESS)
 	{
 		LOG_VULKAN_ERROR(res, "vkQueueSubmit failed: ");
-		PanicAlert("Failed to submit command buffer.");
+//		PanicAlert("Failed to submit command buffer.");
 	}
 
 	// Do we have a swap chain to present?


### PR DESCRIPTION
## Patch

Refactor name replacements with a named map to handle premade text delimiters better.

## Preview 

![image](https://user-images.githubusercontent.com/1380104/116839115-02335380-ab9f-11eb-99d2-1b10534f02db.png)
![image](https://user-images.githubusercontent.com/1380104/116839117-0495ad80-ab9f-11eb-8976-b4f9a1c215b8.png)
