### PR TITLE
Add "start_game" and "end_game" messages to spectator output

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -271,8 +271,7 @@ CEXISlippi::~CEXISlippi()
 	{
 		m_fileWriteThread.join();
 	}
-	m_slippiserver->write(&empty[0], 0);
-	m_slippiserver->endGame();
+	m_slippiserver->endGame(true);
 
 	localSelections.Reset();
 
@@ -2906,6 +2905,7 @@ void CEXISlippi::DMAWrite(u32 _uAddr, u32 _uSize)
 		writeToFileAsync(&memPtr[0], receiveCommandsLen + 1, "create");
 		bufLoc += receiveCommandsLen + 1;
 		g_needInputForFrame = true;
+
 		m_slippiserver->startGame();
 		m_slippiserver->write(&memPtr[0], receiveCommandsLen + 1);
 	}

--- a/Source/Core/Core/Slippi/SlippiSpectate.h
+++ b/Source/Core/Core/Slippi/SlippiSpectate.h
@@ -56,7 +56,8 @@ class SlippiSpectateServer
 	//  when a new client connects to the server mid-match, it can recieve all
 	//  the game events that have happened so far. This buffer needs to be
 	//  cleared when a match ends.
-	void endGame();
+	// If this was called due to dolphin closing then dolphin_closed will be true
+	void endGame(bool dolphin_closed = false);
 
 	// Don't try to copy the class. Delete those functions
 	SlippiSpectateServer(SlippiSpectateServer const &) = delete;

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -293,7 +293,6 @@ bool DolphinApp::OnInit()
 
 	// Init the spectator server
 	SlippiSpectateServer *init = SlippiSpectateServer::getInstance();
-	init->endGame();
 
 	return true;
 }


### PR DESCRIPTION
Ok there is a tiny issue where dolphinConnection in slippi-js doesn't handle these messages so the cursor is off by (one + number of games played since connecting) at the start of each game. This isn't a breaking issue because it will just go along on its merry way ignoring the small hiccup, but this is fixed by https://github.com/project-slippi/slippi-js/pull/66.