### PR TITLE
Fix premature remote input dropping desync

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -1752,7 +1752,7 @@ void CEXISlippi::prepareOpponentInputs(u8 *payload)
 	}
 
 	// the latest read frame instead of the current frame must be passed to avoid nuking inputs
-	// that are > latest sent frame < current frame and arrived during this function
+	// that are > latest read frame < current frame and arrived during this function
 	int32_t minFrameRead = *std::min_element(latestFrameRead, latestFrameRead + SLIPPI_REMOTE_PLAYER_MAX);
 	slippi_netplay->DropOldRemoteInputs(minFrameRead);
 

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -1751,7 +1751,7 @@ void CEXISlippi::prepareOpponentInputs(u8 *payload)
 		m_read_queue.insert(m_read_queue.end(), tx.begin(), tx.end());
 	}
 
-	// the latest sent frame instead of the current frame must be passed to avoid nuking inputs
+	// the latest read frame instead of the current frame must be passed to avoid nuking inputs
 	// that are > latest sent frame < current frame and arrived during this function
 	int32_t minFrameRead = *std::min_element(latestFrameRead, latestFrameRead + SLIPPI_REMOTE_PLAYER_MAX);
 	slippi_netplay->DropOldRemoteInputs(minFrameRead);

--- a/Source/Core/Core/Slippi/SlippiNetplay.cpp
+++ b/Source/Core/Core/Slippi/SlippiNetplay.cpp
@@ -1086,30 +1086,13 @@ void SlippiNetplayClient::DropOldRemoteInputs(int32_t minFrameRead)
 {
 	std::lock_guard<std::mutex> lk(pad_mutex);
 
-	// Remove pad reports that should no longer be needed, compute the lowest frame recieved by
-	// all remote players that can be safely dropped.
-	int lowestCommonFrame = 0;
-	for (int i = 0; i < m_remotePlayerCount; i++)
-	{
-		int playerFrame = 0;
-		for (auto it = remotePadQueue[i].begin(); it != remotePadQueue[i].end(); ++it)
-		{
-			if (it->get()->frame > playerFrame)
-				playerFrame = it->get()->frame;
-		}
-
-		if (lowestCommonFrame == 0 || playerFrame < lowestCommonFrame)
-			lowestCommonFrame = playerFrame;
-	}
-
 	// INFO_LOG(SLIPPI_ONLINE, "Checking for remotePadQueue inputs to drop, lowest common: %d, [0]: %d, [1]: %d, [2]:
 	// %d",
 	//         lowestCommonFrame, playerFrame[0], playerFrame[1], playerFrame[2]);
 	for (int i = 0; i < m_remotePlayerCount; i++)
 	{
 		// INFO_LOG(SLIPPI_ONLINE, "remotePadQueue[%d] size: %d", i, remotePadQueue[i].size());
-		while (remotePadQueue[i].size() > 1 && remotePadQueue[i].back()->frame < lowestCommonFrame &&
-		       remotePadQueue[i].back()->frame < minFrameRead)
+		while (remotePadQueue[i].size() > 1 && remotePadQueue[i].back()->frame < minFrameRead)
 		{
 			// INFO_LOG(SLIPPI_ONLINE, "Popping inputs for frame %d from back of player %d queue",
 			//         remotePadQueue[i].back()->frame, i);

--- a/Source/Core/Core/Slippi/SlippiNetplay.cpp
+++ b/Source/Core/Core/Slippi/SlippiNetplay.cpp
@@ -1082,7 +1082,7 @@ std::unique_ptr<SlippiRemotePadOutput> SlippiNetplayClient::GetSlippiRemotePad(i
 	return std::move(padOutput);
 }
 
-void SlippiNetplayClient::DropOldRemoteInputs(int32_t curFrame)
+void SlippiNetplayClient::DropOldRemoteInputs(int32_t minFrameRead)
 {
 	std::lock_guard<std::mutex> lk(pad_mutex);
 
@@ -1109,7 +1109,7 @@ void SlippiNetplayClient::DropOldRemoteInputs(int32_t curFrame)
 	{
 		// INFO_LOG(SLIPPI_ONLINE, "remotePadQueue[%d] size: %d", i, remotePadQueue[i].size());
 		while (remotePadQueue[i].size() > 1 && remotePadQueue[i].back()->frame < lowestCommonFrame &&
-		       remotePadQueue[i].back()->frame < curFrame)
+		       remotePadQueue[i].back()->frame < minFrameRead)
 		{
 			// INFO_LOG(SLIPPI_ONLINE, "Popping inputs for frame %d from back of player %d queue",
 			//         remotePadQueue[i].back()->frame, i);

--- a/Source/Core/Core/Slippi/SlippiNetplay.h
+++ b/Source/Core/Core/Slippi/SlippiNetplay.h
@@ -135,7 +135,7 @@ class SlippiNetplayClient
 	void SendSlippiPad(std::unique_ptr<SlippiPad> pad);
 	void SetMatchSelections(SlippiPlayerSelections &s);
 	std::unique_ptr<SlippiRemotePadOutput> GetSlippiRemotePad(int32_t curFrame, int index);
-	void DropOldRemoteInputs(int32_t curFrame);
+	void DropOldRemoteInputs(int32_t minFrameRead);
 	SlippiMatchInfo *GetMatchInfo();
 	int32_t GetSlippiLatestRemoteFrame();
 	SlippiPlayerSelections GetSlippiRemoteChatMessage();


### PR DESCRIPTION
This fixes a very rare desync source.

In `CEXISlippi::prepareOpponentInputs`, the remote pad queue may be enriched with new pad data between the construction of the `results` object and the call to `SlippiNetplayClient::DropOldRemoteInputs`. `pad_mutex` is only held during the calls to `SlippiNetplayClient` methods, not throughout all of `CEXISlippi::prepareOpponentInputs`.

This makes the following scenario possible:

We are at frame `n`, and know only the remote inputs up to frame `n-2`
Calls to `GetSlippiRemotePad` happen: the frame number written to the read queue is `n-2`
Inputs for frames `n-1`and `n` arrive and are added to `remotePadQueue`
Call to `DropOldRemoteInputs` happen
The inputs for frames `n-2` and `n-1` ( ! ) get nuked
On the next frame - say `n+1` doesn't arrive - `n` will be passed to the ASM, which will expect to find the data for `n-1` in position 2. But this data doesn't exist anymore and is full 0. The definitive input for frame `n-1` becomes full 0.

This fix makes it so instead of passing the current frame to  `DropOldRemoteInputs`, the lowest frame that we've sent to the ASM is passed instead, forbidding any nuking of inputs past that one. No extra synchronization added.

I don't have replay/logs of this behaviour with vanilla Slippi but I do with a fork of it that makes this problem much more likely to happen due to adding extra work inside `prepareOpponentInputs` i.e more time for inputs to arrive in this precise window. And even then it's quite rare - 2 inputs dropped in 26 games in my latest batch.

Curated extract of logs, Slippi [...] is the read queue content for the other player in singles:

```
In frame 4849 delay 3 pad 0 0 0 0 0 80 0 0 0 0 0 148 
Out result 1 count 1 frame 4847 Slippi [ 1 0 162 243 1 255 0 0 0 0 0 0 ] [ 5 0 165 232 1 255 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] 
4847
4848
4849

In frame 4850 delay 3 pad 0 0 0 0 0 80 0 0 0 0 0 0 
Receiving a packet of inputs from player 1(0) [4849]...
Rcv [4848] -> 03 00 A0 F8 01 FF 00 00
Rcv [4849] -> 02 00 9E FF FA FF 00 00
remotePadQueue[0] size: 3
Popping inputs for frame 4847 from back of player 0 queue
Popping inputs for frame 4848 from back of player 0 queue
Out result 1 count 1 frame 4847 Slippi [ 1 0 162 243 1 255 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] 
4850

In frame 4851 delay 3 pad 0 0 0 0 0 80 0 0 0 0 0 0 
Out result 1 count 1 frame 4849 Slippi [ 2 0 158 255 250 255 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] 
4848 // Note the full 0 second pad
4849 
4850
4851

In frame 4852 delay 3 pad 0 0 0 0 0 80 0 0 0 0 0 0 
Out result 1 count 1 frame 4850 Slippi [ 2 0 158 1 195 185 0 0 0 0 0 0 ] [ 2 0 158 255 250 255 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] [ 0 0 0 0 0 0 0 0 0 0 0 0 ] 
4850
4851
4852
```
