### PR TITLE
Fix crash when players have commas in their names

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -41,7 +41,7 @@
 #define SLEEP_TIME_MS 8
 #define WRITE_FILE_SLEEP_TIME_MS 85
 
-#define LOCAL_TESTING
+//#define LOCAL_TESTING
 //#define CREATE_DIFF_FILES
 
 static std::unordered_map<u8, std::string> slippi_names;
@@ -253,9 +253,9 @@ CEXISlippi::CEXISlippi()
 	//                        "C:\\Users\\Jas\\Documents\\Melee\\Textures\\Slippi\\MainMenu\\MnMaAll-restored.usd");
 #endif
 
-	    auto spt = SlippiPremadeText();
-	    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "kim,b", "Test");
-	    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "ラピ,ト", "Test");
+//	    auto spt = SlippiPremadeText();
+//	    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "Player 1", "Test");
+//	    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "ラピ,ト", "Test");
 }
 
 CEXISlippi::~CEXISlippi()
@@ -2189,7 +2189,7 @@ void CEXISlippi::prepareOnlineMatchState()
 	chatMessagePlayerIdx = 0;
 	localChatMessageId = 0;
 	// in CSS p1 is always current player and p2 is opponent
-	localPlayerName = p1Name = "kim,b";
+	localPlayerName = p1Name = "Player 1";
 	oppName = p2Name = "Player 2";
 #endif
 
@@ -2475,7 +2475,7 @@ void CEXISlippi::prepareOnlineMatchState()
 	m_read_queue.insert(m_read_queue.end(), localPlayerName.begin(), localPlayerName.end());
 
 #ifdef LOCAL_TESTING
-	std::string defaultNames[] = {"kim,b", "Player 2", "Player 3", "Player 4"};
+	std::string defaultNames[] = {"Player 1", "Player 2", "Player 3", "Player 4"};
 #endif
 
 	for (int i = 0; i < 4; i++)
@@ -2674,7 +2674,7 @@ std::vector<u8> CEXISlippi::loadPremadeText(u8 *payload)
 		if (matchmaking)
 			playerName = matchmaking->GetPlayerName(port);
 #ifdef LOCAL_TESTING
-		std::string defaultNames[] = {"kim,b", "lol u lost 2 dk", "Player 3", "Player 4"};
+		std::string defaultNames[] = {"Player 1", "Player 2", "Player 3", "Player 4"};
 		playerName = defaultNames[port];
 #endif
 

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -41,7 +41,7 @@
 #define SLEEP_TIME_MS 8
 #define WRITE_FILE_SLEEP_TIME_MS 85
 
-//#define LOCAL_TESTING
+#define LOCAL_TESTING
 //#define CREATE_DIFF_FILES
 
 static std::unordered_map<u8, std::string> slippi_names;
@@ -253,9 +253,9 @@ CEXISlippi::CEXISlippi()
 	//                        "C:\\Users\\Jas\\Documents\\Melee\\Textures\\Slippi\\MainMenu\\MnMaAll-restored.usd");
 #endif
 
-	//    auto spt = SlippiPremadeText();
-	//    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "Rapito", "Test");
-	//    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "ラピト", "Test");
+	    auto spt = SlippiPremadeText();
+	    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "kim,b", "Test");
+	    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "ラピ,ト", "Test");
 }
 
 CEXISlippi::~CEXISlippi()
@@ -2189,7 +2189,7 @@ void CEXISlippi::prepareOnlineMatchState()
 	chatMessagePlayerIdx = 0;
 	localChatMessageId = 0;
 	// in CSS p1 is always current player and p2 is opponent
-	localPlayerName = p1Name = "Player 1";
+	localPlayerName = p1Name = "kim,b";
 	oppName = p2Name = "Player 2";
 #endif
 
@@ -2475,7 +2475,7 @@ void CEXISlippi::prepareOnlineMatchState()
 	m_read_queue.insert(m_read_queue.end(), localPlayerName.begin(), localPlayerName.end());
 
 #ifdef LOCAL_TESTING
-	std::string defaultNames[] = {"Player 1", "Player 2", "Player 3", "Player 4"};
+	std::string defaultNames[] = {"kim,b", "Player 2", "Player 3", "Player 4"};
 #endif
 
 	for (int i = 0; i < 4; i++)
@@ -2674,7 +2674,7 @@ std::vector<u8> CEXISlippi::loadPremadeText(u8 *payload)
 		if (matchmaking)
 			playerName = matchmaking->GetPlayerName(port);
 #ifdef LOCAL_TESTING
-		std::string defaultNames[] = {"Player 1", "lol u lost 2 dk", "Player 3", "Player 4"};
+		std::string defaultNames[] = {"kim,b", "lol u lost 2 dk", "Player 3", "Player 4"};
 		playerName = defaultNames[port];
 #endif
 

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -254,8 +254,8 @@ CEXISlippi::CEXISlippi()
 #endif
 
 	//    auto spt = SlippiPremadeText();
-	//    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "Player 1", "Test");
-	//    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "ラピ,ト", "Test");
+	//    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "Rapito", "Test");
+	//    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "ラピト", "Test");
 }
 
 CEXISlippi::~CEXISlippi()

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -253,9 +253,9 @@ CEXISlippi::CEXISlippi()
 	//                        "C:\\Users\\Jas\\Documents\\Melee\\Textures\\Slippi\\MainMenu\\MnMaAll-restored.usd");
 #endif
 
-//	    auto spt = SlippiPremadeText();
-//	    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "Player 1", "Test");
-//	    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "ラピ,ト", "Test");
+	//    auto spt = SlippiPremadeText();
+	//    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "Player 1", "Test");
+	//    spt.GetPremadeTextData(SlippiPremadeText::SPT_CHAT_P1, "ラピ,ト", "Test");
 }
 
 CEXISlippi::~CEXISlippi()
@@ -2674,7 +2674,7 @@ std::vector<u8> CEXISlippi::loadPremadeText(u8 *payload)
 		if (matchmaking)
 			playerName = matchmaking->GetPlayerName(port);
 #ifdef LOCAL_TESTING
-		std::string defaultNames[] = {"Player 1", "Player 2", "Player 3", "Player 4"};
+		std::string defaultNames[] = {"Player 1", "lol u lost 2 dk", "Player 3", "Player 4"};
 		playerName = defaultNames[port];
 #endif
 

--- a/Source/Core/Core/Slippi/SlippiPremadeText.h
+++ b/Source/Core/Core/Slippi/SlippiPremadeText.h
@@ -190,7 +190,7 @@ class SlippiPremadeText
 				}
 				else
 				{
-                    // DEBUG_LOG(SLIPPI, "TEST:::: %s %s", firstMatch.c_str(), UTF32toUTF8(utfMatch).c_str());
+					// DEBUG_LOG(SLIPPI, "TEST:::: %s %s", firstMatch.c_str(), UTF32toUTF8(utfMatch).c_str());
 					for (unsigned long c = 0; c < utfMatch.length(); c++)
 					{
 

--- a/Source/Core/Core/Slippi/SlippiPremadeText.h
+++ b/Source/Core/Core/Slippi/SlippiPremadeText.h
@@ -98,7 +98,7 @@ class SlippiPremadeText
 		va_start(args, textId);
 		vsprintf(str, format.c_str(), args);
 		va_end(args);
-		//				DEBUG_LOG(SLIPPI, "%s", str);
+		// DEBUG_LOG(SLIPPI, "%s", str);
 
 		vector<u8> data = {};
 		vector<u8> empty = {};
@@ -190,8 +190,7 @@ class SlippiPremadeText
 				}
 				else
 				{
-					//DEBUG_LOG(SLIPPI, "TEST:::: %s %s", firstMatch.c_str(),
-					//UTF32toUTF8(utfMatch).c_str());
+                    // DEBUG_LOG(SLIPPI, "TEST:::: %s %s", firstMatch.c_str(), UTF32toUTF8(utfMatch).c_str());
 					for (unsigned long c = 0; c < utfMatch.length(); c++)
 					{
 
@@ -218,7 +217,7 @@ class SlippiPremadeText
 								break;
 							}
 						}
-						//DEBUG_LOG(SLIPPI, "pos:%d chr:%c map:%d", pos, chr, CHAR_MAP[pos]);
+						// DEBUG_LOG(SLIPPI, "pos:%d chr:%c map:%d", pos, chr, CHAR_MAP[pos]);
 
 						if (pos >= 0)
 						{

--- a/Source/Core/Core/Slippi/SlippiPremadeText.h
+++ b/Source/Core/Core/Slippi/SlippiPremadeText.h
@@ -84,7 +84,7 @@ class SlippiPremadeText
 	unordered_map<string, string> unsupportedStringMap = {
 	    {"<", "\\"},
 	    {">", "`"},
-	    {",", "Ç"},
+	    {",", ""}, // DELETE U+007F
 	};
 
 	// TODO: use va_list to handle any no. or args
@@ -102,7 +102,7 @@ class SlippiPremadeText
 
 		vector<u8> data = {};
 		vector<u8> empty = {};
-
+		 
 		vector<string> matches = vector<string>();
 
 		// NOTE: This code is converted from HSDRaw C# code
@@ -199,8 +199,8 @@ class SlippiPremadeText
 						// and we need to prevent "format injection" lol...
 						for (auto it = unsupportedStringMap.begin(); it != unsupportedStringMap.end(); it++)
 						{
-							if (it->second.find(chr) != std::string::npos || (chr == U'Ç' && it->first[0] == ','))
-							{ // Need to figure out how to find extended ascii chars (Ç)
+							if (it->second.find(chr) != std::string::npos || (chr == U'' && it->first[0] == ','))
+							{ // Need to figure out how to find extended ascii chars ()
 								chr = it->first[0];
 							}
 						}

--- a/Source/Core/Core/Slippi/SlippiPremadeText.h
+++ b/Source/Core/Core/Slippi/SlippiPremadeText.h
@@ -98,11 +98,11 @@ class SlippiPremadeText
 		va_start(args, textId);
 		vsprintf(str, format.c_str(), args);
 		va_end(args);
-				DEBUG_LOG(SLIPPI, "%s", str);
+		//				DEBUG_LOG(SLIPPI, "%s", str);
 
 		vector<u8> data = {};
 		vector<u8> empty = {};
-		 
+
 		vector<string> matches = vector<string>();
 
 		// NOTE: This code is converted from HSDRaw C# code
@@ -190,7 +190,8 @@ class SlippiPremadeText
 				}
 				else
 				{
-					 DEBUG_LOG(SLIPPI, "TEST:::: %s %s", firstMatch.c_str(), UTF32toUTF8(utfMatch).c_str());
+					//DEBUG_LOG(SLIPPI, "TEST:::: %s %s", firstMatch.c_str(),
+					//UTF32toUTF8(utfMatch).c_str());
 					for (unsigned long c = 0; c < utfMatch.length(); c++)
 					{
 
@@ -217,7 +218,7 @@ class SlippiPremadeText
 								break;
 							}
 						}
-						 DEBUG_LOG(SLIPPI, "pos:%d chr:%c map:%d", pos, chr, CHAR_MAP[pos]);
+						//DEBUG_LOG(SLIPPI, "pos:%d chr:%c map:%d", pos, chr, CHAR_MAP[pos]);
 
 						if (pos >= 0)
 						{

--- a/Source/Core/Core/Slippi/SlippiPremadeText.h
+++ b/Source/Core/Core/Slippi/SlippiPremadeText.h
@@ -98,7 +98,7 @@ class SlippiPremadeText
 		va_start(args, textId);
 		vsprintf(str, format.c_str(), args);
 		va_end(args);
-		//		DEBUG_LOG(SLIPPI, "%s", str);
+				DEBUG_LOG(SLIPPI, "%s", str);
 
 		vector<u8> data = {};
 		vector<u8> empty = {};
@@ -190,7 +190,7 @@ class SlippiPremadeText
 				}
 				else
 				{
-					// DEBUG_LOG(SLIPPI, "TEST:::: %s %s", firstMatch.c_str(), UTF32toUTF8(utfMatch).c_str());
+					 DEBUG_LOG(SLIPPI, "TEST:::: %s %s", firstMatch.c_str(), UTF32toUTF8(utfMatch).c_str());
 					for (unsigned long c = 0; c < utfMatch.length(); c++)
 					{
 
@@ -217,7 +217,7 @@ class SlippiPremadeText
 								break;
 							}
 						}
-						// DEBUG_LOG(SLIPPI, "pos:%d chr:%c map:%d", pos, chr, CHAR_MAP[pos]);
+						 DEBUG_LOG(SLIPPI, "pos:%d chr:%c map:%d", pos, chr, CHAR_MAP[pos]);
 
 						if (pos >= 0)
 						{

--- a/Source/Core/DolphinWX/LogWindow.cpp
+++ b/Source/Core/DolphinWX/LogWindow.cpp
@@ -218,7 +218,7 @@ wxTextCtrl* CLogWindow::CreateTextCtrl(wxPanel* parent, wxWindowID id, long Styl
 	wxTextCtrl* TC =
 		new wxTextCtrl(parent, id, wxEmptyString, wxDefaultPosition, wxDefaultSize, Style);
 #ifdef __APPLE__
-	TC->SetBackgroundColour(*wxLIGHT_GREY);
+	TC->SetBackgroundColour(*wxBLACK);
 #else
 	TC->SetBackgroundColour(*wxBLACK);
 #endif


### PR DESCRIPTION
This patch uses an ASCII character that is within the ranges that UTF8to32 can handle on Windows.
+ This also turns MacOS log window to black so we can actually read them