### PR TITLE
Print assert message as string, not as format

### DIFF
--- a/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
+++ b/Source/Core/Core/PowerPC/Interpreter/Interpreter.cpp
@@ -306,7 +306,7 @@ void Interpreter::unknown_instruction(UGeckoInstruction _inst)
     msg.append(it->Name);
   }
 
-  _assert_msg_(POWERPC, 0, msg.c_str());
+  _assert_msg_(POWERPC, 0, "%s", msg.c_str());
 }
 
 void Interpreter::ClearCache()


### PR DESCRIPTION
The 3rd argument to _assert_msg_ is passed to MsgAlert, and will be
interpreted as a format string. This is not intended behavior for the
msg passed here, so we fix the print by formatting msg as a regular C
string. This also fixes a compiler error (-Werror=format-security) when
building with GCC.