### PR TITLE
Fix pixbuf error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,10 +73,8 @@ semver.pdb
 semver.log
 
 AppDir/
-linuxdeploy
 linuxdeploy-update-plugin
 appimageupdatetool
-Tools/linuxdeploy
 Tools/linuxdeploy-update-plugin
 Tools/appimageupdatetool
 Tools/*.AppImage

--- a/build-appimage.sh
+++ b/build-appimage.sh
@@ -26,16 +26,17 @@ APPDIR_HOOKS="./AppDir/apprun-hooks"
 # Grab various appimage binaries from GitHub if we don't have them
 if [ ! -e ./Tools/linuxdeploy ]; then
 	wget ${LINUXDEPLOY_URL} -O ./Tools/linuxdeploy
-	chmod +x ./Tools/linuxdeploy
 fi
 if [ ! -e ./Tools/linuxdeploy-update-plugin ]; then
 	wget ${UPDATEPLUG_URL} -O ./Tools/linuxdeploy-update-plugin
-	chmod +x ./Tools/linuxdeploy-update-plugin
 fi
 if [ ! -e ./Tools/appimageupdatetool ]; then
 	wget ${UPDATETOOL_URL} -O ./Tools/appimageupdatetool
-	chmod +x ./Tools/appimageupdatetool
 fi
+
+chmod +x ./Tools/linuxdeploy
+chmod +x ./Tools/linuxdeploy-update-plugin
+chmod +x ./Tools/appimageupdatetool
 
 # Delete the AppDir folder to prevent build issues
 rm -rf ./AppDir/


### PR DESCRIPTION
this is so stupid, but the latest version of linux deploy is busted for us. We are now using the build from https://github.com/linuxdeploy/linuxdeploy/tree/b7c97856266809601a4fd6e83ebcd0be217ec802.


```
(AppRun.wrapped:53436): GdkPixbuf-WARNING **: 20:15:14.489: Cannot open pixbuf loader module file '/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders.cache': No such file or directory
 
This likely means that your installation is broken.
Try running the command
  gdk-pixbuf-query-loaders > /usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders.cache
to make things work again for the time being.
Gtk-Message: 20:15:14.514: Failed to load module "canberra-gtk-module"
Gtk-Message: 20:15:14.514: Failed to load module "pk-gtk-module"
Gtk-Message: 20:15:14.515: Failed to load module "canberra-gtk-module"
Gtk-Message: 20:15:14.515: Failed to load module "pk-gtk-module"
 
(AppRun.wrapped:53436): GdkPixbuf-WARNING **: 20:15:14.629: Cannot open pixbuf loader module file '/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders.cache': No such file or directory
 
This likely means that your installation is broken.
Try running the command
  gdk-pixbuf-query-loaders > /usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders.cache
to make things work again for the time being.
 
(AppRun.wrapped:53436): Gtk-WARNING **: 20:15:14.629: Could not load a pixbuf from icon theme.
This may indicate that pixbuf loaders or the mime database could not be found.
 
(AppRun.wrapped:53436): GdkPixbuf-WARNING **: 20:15:14.629: Cannot open pixbuf loader module file '/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders.cache': No such file or directory
 
This likely means that your installation is broken.
Try running the command
  gdk-pixbuf-query-loaders > /usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders.cache
to make things work again for the time being.
**
Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /usr/share/icons/Adwaita/16x16/status/image-missing.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
Bail out! Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /usr/share/icons/Adwaita/16x16/status/image-missing.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
[1]    53436 IOT instruction (core dumped)  ./Slippi_Playback-x86_64.AppImage
```