### PR TITLE
Disable WebView on Linux & Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -932,12 +932,12 @@ endif()
 if(NOT DISABLE_WX)
 	include(FindwxWidgets OPTIONAL)
 
-    # This is increasingly not touched, but the clarity is probably beneficial to keep around.
-    if(APPLE)
-	    FIND_PACKAGE(wxWidgets COMPONENTS core aui adv webview)
-    else()
-	    FIND_PACKAGE(wxWidgets COMPONENTS core aui adv)
-    endif()
+	# This is increasingly not touched, but the clarity is probably beneficial to keep around.
+	if(APPLE)
+		FIND_PACKAGE(wxWidgets COMPONENTS core aui adv webview)
+	else()
+		FIND_PACKAGE(wxWidgets COMPONENTS core aui adv)
+	endif()
 
 	if(_ARCH_32)
 		add_definitions(-DwxSIZE_T_IS_UINT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -931,7 +931,13 @@ endif()
 
 if(NOT DISABLE_WX)
 	include(FindwxWidgets OPTIONAL)
-	FIND_PACKAGE(wxWidgets COMPONENTS core aui adv webview)
+
+    # This is increasingly not touched, but the clarity is probably beneficial to keep around.
+    if(APPLE)
+	    FIND_PACKAGE(wxWidgets COMPONENTS core aui adv webview)
+    else()
+	    FIND_PACKAGE(wxWidgets COMPONENTS core aui adv)
+    endif()
 
 	if(_ARCH_32)
 		add_definitions(-DwxSIZE_T_IS_UINT)

--- a/Externals/wxWidgets3/wx/wxgtk.h
+++ b/Externals/wxWidgets3/wx/wxgtk.h
@@ -783,7 +783,7 @@
 // Default is 1
 //
 // Recommended setting: 1
-#define wxUSE_WEBVIEW 1
+#define wxUSE_WEBVIEW 0
 
 // Use the IE wxWebView backend
 //
@@ -791,7 +791,7 @@
 //
 // Recommended setting: 1
 #ifdef __WXMSW__
-#define wxUSE_WEBVIEW_IE 1
+#define wxUSE_WEBVIEW_IE 0
 #else
 #define wxUSE_WEBVIEW_IE 0
 #endif
@@ -809,7 +809,7 @@
 //
 // Recommended setting: 1
 #if (defined(__WXGTK__) && !defined(__WXGTK3__)) || defined(__WXOSX__)
-#define wxUSE_WEBVIEW_WEBKIT 1
+#define wxUSE_WEBVIEW_WEBKIT 0
 #else
 #define wxUSE_WEBVIEW_WEBKIT 0
 #endif
@@ -820,7 +820,7 @@
 //
 // Recommended setting: 1
 #if defined(__WXGTK3__)
-#define wxUSE_WEBVIEW_WEBKIT2 1
+#define wxUSE_WEBVIEW_WEBKIT2 0
 #else
 #define wxUSE_WEBVIEW_WEBKIT2 0
 #endif

--- a/Externals/wxWidgets3/wx/wxmsw.h
+++ b/Externals/wxWidgets3/wx/wxmsw.h
@@ -717,13 +717,13 @@
 // Default is 1
 //
 // Recommended setting: 1
-#define wxUSE_WEBVIEW 1
+#define wxUSE_WEBVIEW 0
 
 // Use the Edge wxWebView backend.
 //
 // NOTE: This is important! If this isn't done, you'll
 // wind up with IE...7.
-#define wxUSE_WEBVIEW_EDGE 1
+#define wxUSE_WEBVIEW_EDGE 0
 
 // Use the IE wxWebView backend
 //

--- a/Source/Core/Core/Slippi/SlippiUser.cpp
+++ b/Source/Core/Core/Slippi/SlippiUser.cpp
@@ -17,7 +17,10 @@
 
 #include "DolphinWX/Frame.h"
 #include "DolphinWX/Main.h"
+
+#ifdef __APPLE__
 #include "DolphinWX/SlippiAuthWebView/SlippiAuthWebView.h"
+#endif
 
 #include "VideoCommon/OnScreenDisplay.h"
 
@@ -148,39 +151,38 @@ bool SlippiUser::AttemptLogin()
 	return isLoggedIn;
 }
 
-// macOS and Linux have modern WebKit views (in our wxWidgets build) that can pop open and enable login
-// with relative ease; Windows unfortunately requires an extra check as Edge may not be present yet.
+// On macOS, this will pop open a built-in webview to handle authentication. This is likely to see less and less
+// use over time but should hang around for a bit longer; macOS in particular benefits from having this for some
+// testing scenarios due to the cumbersome user.json location placement on that system.
 //
-// If it's not, they just get routed to the older method (pop them over to browser and guide
-// them to place the file).
+// Windows and Linux don't have reliable WebView components, so this just pops the user over to slippi.gg for those
+// platforms.
 void SlippiUser::OpenLogInPage()
 {
-#ifdef _WIN32
-	// Uncomment this if Windows is in a position to try the login flow.
-	//if (!SlippiAuthWebView::IsAvailable())
-	//{
-		std::string url = "https://slippi.gg/online/enable";
-		std::string path = File::GetSlippiUserJSONPath();
-
-		// On windows, sometimes the path can have backslashes and slashes mixed, convert all to backslashes
-		path = ReplaceAll(path, "\\", "\\");
-		path = ReplaceAll(path, "/", "\\");
-
-		std::string fullUrl = url + "?path=" + path;
-		INFO_LOG(SLIPPI_ONLINE, "[User] Login at path: %s", fullUrl.c_str());
-
-		std::string command = "explorer \"" + fullUrl + "\"";
-		RunSystemCommand(command);
-		return;
-	//}
-#endif
-
-	// macOS and Linux have stable WebView components that we can use to
-	// enable an easier login flow for users. On macOS, this is backed by
-	// the system-integrated WebKit framework. On Linux, this is provided
-	// by linking Webkit2.
+#ifdef __APPLE__
 	CFrame *cframe = wxGetApp().GetCFrame();
 	cframe->OpenSlippiAuthenticationDialog();
+#else
+    std::string url = "https://slippi.gg/online/enable";
+    std::string path = File::GetSlippiUserJSONPath();
+
+#ifdef _WIN32
+    // On windows, sometimes the path can have backslashes and slashes mixed, convert all to backslashes
+    path = ReplaceAll(path, "\\", "\\");
+    path = ReplaceAll(path, "/", "\\");
+#endif
+
+    std::string fullUrl = url + "?path=" + path;
+    INFO_LOG(SLIPPI_ONLINE, "[User] Login at path: %s", fullUrl.c_str());
+
+#ifdef _WIN32
+    std::string command = "explorer \"" + fullUrl + "\"";
+#else
+    std::string command = "xdg-open \"" + fullUrl + "\""; // Linux
+#endif
+
+    RunSystemCommand(command);
+#endif
 }
 
 bool SlippiUser::UpdateApp()
@@ -207,7 +209,9 @@ bool SlippiUser::UpdateApp()
 	return true;
 #elif defined(__APPLE__)
 	CriticalAlertT(
-	    "Automatic updates are not available for macOS, please get the latest update from slippi.gg/netplay.");
+	    "Automatic updates are not available for standalone Netplay builds on macOS. Please get the latest update from slippi.gg/netplay. "
+        "(The Slippi Launcher has automatic updates on macOS, and you should consider switching to that)"
+    );
 	return false;
 #else
 	const char *appimage_path = getenv("APPIMAGE");

--- a/Source/Core/Core/Slippi/SlippiUser.cpp
+++ b/Source/Core/Core/Slippi/SlippiUser.cpp
@@ -163,25 +163,25 @@ void SlippiUser::OpenLogInPage()
 	CFrame *cframe = wxGetApp().GetCFrame();
 	cframe->OpenSlippiAuthenticationDialog();
 #else
-    std::string url = "https://slippi.gg/online/enable";
-    std::string path = File::GetSlippiUserJSONPath();
+	std::string url = "https://slippi.gg/online/enable";
+	std::string path = File::GetSlippiUserJSONPath();
 
 #ifdef _WIN32
-    // On windows, sometimes the path can have backslashes and slashes mixed, convert all to backslashes
-    path = ReplaceAll(path, "\\", "\\");
-    path = ReplaceAll(path, "/", "\\");
+	// On windows, sometimes the path can have backslashes and slashes mixed, convert all to backslashes
+	path = ReplaceAll(path, "\\", "\\");
+	path = ReplaceAll(path, "/", "\\");
 #endif
 
-    std::string fullUrl = url + "?path=" + path;
-    INFO_LOG(SLIPPI_ONLINE, "[User] Login at path: %s", fullUrl.c_str());
+	std::string fullUrl = url + "?path=" + path;
+	INFO_LOG(SLIPPI_ONLINE, "[User] Login at path: %s", fullUrl.c_str());
 
 #ifdef _WIN32
-    std::string command = "explorer \"" + fullUrl + "\"";
+	std::string command = "explorer \"" + fullUrl + "\"";
 #else
-    std::string command = "xdg-open \"" + fullUrl + "\""; // Linux
+	std::string command = "xdg-open \"" + fullUrl + "\""; // Linux
 #endif
 
-    RunSystemCommand(command);
+	RunSystemCommand(command);
 #endif
 }
 
@@ -209,9 +209,9 @@ bool SlippiUser::UpdateApp()
 	return true;
 #elif defined(__APPLE__)
 	CriticalAlertT(
-	    "Automatic updates are not available for standalone Netplay builds on macOS. Please get the latest update from slippi.gg/netplay. "
-        "(The Slippi Launcher has automatic updates on macOS, and you should consider switching to that)"
-    );
+		"Automatic updates are not available for standalone Netplay builds on macOS. Please get the latest update from slippi.gg/netplay. "
+		"(The Slippi Launcher has automatic updates on macOS, and you should consider switching to that)"
+	);
 	return false;
 #else
 	const char *appimage_path = getenv("APPIMAGE");

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -109,8 +109,8 @@ if(APPLE)
             ${WEBKIT_FRAMEWORK}
 			)
 
-        # Keep the WebView login portal around only on macOS, just a bit longer
-        set(GUI_SRCS ${GUI_SRCS} SlippiAuthWebView/SlippiAuthWebView.cpp)
+		# Keep the WebView login portal around only on macOS, just a bit longer
+		set(GUI_SRCS ${GUI_SRCS} SlippiAuthWebView/SlippiAuthWebView.cpp)
 	endif()
 
 	# Add resource files to application bundle.

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -72,7 +72,6 @@ set(GUI_SRCS
 	MemcardManager.cpp
 	PatchAddEdit.cpp
 	PostProcessingConfigDiag.cpp
-    SlippiAuthWebView/SlippiAuthWebView.cpp
 	SoftwareVideoConfigDialog.cpp
 	TASInputDlg.cpp
 	VideoConfigDiag.cpp
@@ -109,7 +108,11 @@ if(APPLE)
             ${OPENGL_LIBRARY}
             ${WEBKIT_FRAMEWORK}
 			)
+
+        # Keep the WebView login portal around only on macOS, just a bit longer
+        set(GUI_SRCS ${GUI_SRCS} SlippiAuthWebView/SlippiAuthWebView.cpp)
 	endif()
+
 	# Add resource files to application bundle.
 	set(RESOURCES resources/Dolphin.icns)
 	list(APPEND SRCS ${RESOURCES})

--- a/Source/Core/DolphinWX/Dolphin.vcxproj
+++ b/Source/Core/DolphinWX/Dolphin.vcxproj
@@ -163,7 +163,6 @@
     <ClCompile Include="MemcardManager.cpp" />
     <ClCompile Include="NetPlay\PadMapDialog.cpp" />
     <ClCompile Include="PatchAddEdit.cpp" />
-    <ClCompile Include="SlippiAuthWebView\SlippiAuthWebView.cpp" />
     <ClCompile Include="SoftwareVideoConfigDialog.cpp" />
     <ClCompile Include="TASInputDlg.cpp" />
     <ClCompile Include="VideoConfigDiag.cpp" />
@@ -242,7 +241,6 @@
     <ClInclude Include="MainToolBar.h" />
     <ClInclude Include="MemcardManager.h" />
     <ClInclude Include="PatchAddEdit.h" />
-    <ClInclude Include="SlippiAuthWebView\SlippiAuthWebView.h" />
     <ClInclude Include="SoftwareVideoConfigDialog.h" />
     <ClInclude Include="TASInputDlg.h" />
     <ClInclude Include="VideoConfigDiag.h" />

--- a/Source/Core/DolphinWX/Dolphin.vcxproj.filters
+++ b/Source/Core/DolphinWX/Dolphin.vcxproj.filters
@@ -263,7 +263,6 @@
     <ClCompile Include="Config\SlippiConfigPane.cpp">
       <Filter>GUI\Config</Filter>
     </ClCompile>
-    <ClCompile Include="SlippiAuthWebView\SlippiAuthWebView.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Main.h" />
@@ -486,7 +485,6 @@
     <ClInclude Include="Config\SlippiConfigPane.h">
       <Filter>GUI\Config</Filter>
     </ClInclude>
-    <ClInclude Include="SlippiAuthWebView\SlippiAuthWebView.h" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />

--- a/Source/Core/DolphinWX/Frame.h
+++ b/Source/Core/DolphinWX/Frame.h
@@ -21,7 +21,11 @@
 #include "Core/Slippi/SlippiTimer.h"
 #include "DolphinWX/Globals.h"
 #include "DolphinWX/PlaybackSlider.h"
+
+#ifdef __APPLE__
 #include "DolphinWX/SlippiAuthWebView/SlippiAuthWebView.h"
+#endif
+
 #include "InputCommon/GCPadStatus.h"
 
 #if defined(HAVE_X11) && HAVE_X11
@@ -117,7 +121,11 @@ public:
 	void DoExclusiveFullscreen(bool enable_fullscreen);
 	void ToggleDisplayMode(bool bFullscreen);
 	void ToggleScreenSaver(bool enable);
+
+#ifdef __APPLE__
     void OpenSlippiAuthenticationDialog();
+#endif
+
 	static void ConnectWiimote(int wm_idx, bool connect);
 	void UpdateTitle(const std::string& str);
 	void OpenGeneralConfiguration(wxWindowID tab_id = wxID_ANY);
@@ -153,7 +161,11 @@ public:
 private:
 	CGameListCtrl* m_GameListCtrl = nullptr;
 	CConfigMain* m_main_config_dialog = nullptr;
+
+#ifdef __APPLE__
     SlippiAuthWebView* m_slippi_auth_dialog = nullptr;
+#endif
+
 	wxPanel* m_Panel = nullptr;
 	CRenderFrame* m_RenderFrame = nullptr;
 	wxWindow* m_RenderParent = nullptr;
@@ -193,7 +205,10 @@ private:
 	void BindMenuBarEvents();
 	void BindDebuggerMenuBarEvents();
 	void BindDebuggerMenuBarUpdateEvents();
+
+#ifdef __APPLE__
     void ShowSlippiAuthenticationDialog();
+#endif
 
 	wxToolBar* OnCreateToolBar(long style, wxWindowID id, const wxString& name) override;
 	wxMenuBar* CreateMenuBar() const;

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -270,6 +270,8 @@ void CFrame::OpenGeneralConfiguration(wxWindowID tab_id)
 	m_main_config_dialog->SetFocus();
 }
 
+// Only macOS has WebView support.
+#ifdef __APPLE__
 // Actually create and show the wxWebView control.
 void CFrame::ShowSlippiAuthenticationDialog()
 {
@@ -285,6 +287,7 @@ void CFrame::OpenSlippiAuthenticationDialog()
 {
     CallAfter(&CFrame::ShowSlippiAuthenticationDialog);
 }
+#endif
 
 // Menu items
 

--- a/Source/Core/DolphinWX/SlippiAuthWebView/SlippiAuthWebView.h
+++ b/Source/Core/DolphinWX/SlippiAuthWebView/SlippiAuthWebView.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#ifdef __APPLE__
 #include <wx/dialog.h>
 #include <wx/webview.h>
 #include "Common/CommonTypes.h"
@@ -24,3 +25,4 @@ private:
 
     wxWebView* m_browser;
 };
+#endif


### PR DESCRIPTION
Disables the WebView pieces on Windows (where Microsoft doesn't ship WebView2 anyway...) and Linux (where it causes some odd linking issues on various distros).

- Specifies the Externals/wxWidgets build to not link any WebView
  control on those platforms.
- Blocks off the code on the various DolphinWX components to only link
  and/or run on macOS.
- Restores `xgd-open` on Linux for the increasingly rare cases where
  that code path should be getting hit.

The reasoning for keeping this around on macOS is somewhat selfish -
it's just easier for me to pass a test build for a one-off change to
users who might otherwise not understand the macOS bundle and AppSupport
architecture.