### PR TITLE
macOS: Default to Vulkan for rendering

### DIFF
--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -94,17 +94,17 @@ void VideoBackendBase::PopulateList()
 	// we're doing is shoving Vulkan to the front if it's macOS 10.14 or later, so it loads first.
 	if(PlatformSupportsVulkan()) {
 #ifdef __APPLE__
-	if (__builtin_available(macOS 10.14, *)) {
-		g_available_video_backends.emplace(
-			g_available_video_backends.begin(),
-			std::make_unique<Vulkan::VideoBackend>()
-		);
-	} 
-	else
+		if (__builtin_available(macOS 10.14, *)) {
+			g_available_video_backends.emplace(
+				g_available_video_backends.begin(),
+				std::make_unique<Vulkan::VideoBackend>()
+			);
+		} 
+		else
 #endif
-        {
-	        g_available_video_backends.push_back(std::make_unique<Vulkan::VideoBackend>());
-        }
+        	{
+	        	g_available_video_backends.push_back(std::make_unique<Vulkan::VideoBackend>());
+        	}
     }
 
 	// Disable software video backend as is currently not working


### PR DESCRIPTION
This mirrors a [recent change in mainline Dolphin](https://github.com/dolphin-emu/dolphin/pull/9962), so should be relatively safe to do. Tested locally (Big Sur M1, Catalina Intel) and no issues found, but I lack a High Sierra machine to test on. I am reasonably confident it'll be fine though.

I've wanted to PR this for quite some time but was unsure if I'd be missing some context, but mainline having done it coupled with most Slippi macOS users needing it for performance makes me far more confident.