### PR TITLE
replace disc name check with file check

### DIFF
--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -14,6 +14,8 @@
 #include "Core/HW/EXI_Device.h"
 #include "Core/HW/SI_Device.h"
 
+#include "DiscIO/Filesystem.h"
+
 namespace DiscIO
 {
 enum class Language;
@@ -60,8 +62,7 @@ enum GameType
 	GAMETYPE_MELEE_NTSC,
 	GAMETYPE_MELEE_20XX,
 	GAMETYPE_MELEE_UPTM,
-	GAMETYPE_MELEE_AKANEIA,
-	GAMETYPE_MELEE_BEYOND,
+	GAMETYPE_MELEE_MEX,
 };
 
 enum PollingMethod
@@ -293,6 +294,8 @@ struct SConfig : NonCopyable
 	void CheckMemcardPath(std::string &memcardPath, const std::string &gameRegion, bool isSlotA);
 	DiscIO::Language GetCurrentLanguage(bool wii) const;
 
+	bool CheckDirectoryForFile(const std::vector<DiscIO::SFileInfo> &file_infos, const size_t first_index,
+	                           const size_t last_index, const std::string &filename, size_t &current_index) const;
 	u16 GetGameRevision() const;
 	std::string GetGameID_Wrapper() const;
 	bool GameHasDefaultGameIni() const;

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -158,8 +158,7 @@ static bool InstallCodeHandler()
     // SConfig::GetMeleeCapabilities(CAPABILITY_GECKO_CODE) // returns boolean
     // SConfig::GetMeleeCapabilities(CAPABILITY_SLIPPI_TEAMS) // returns boolean   
 	if (SConfig::GetInstance().m_gameType == GAMETYPE_MELEE_NTSC    || 
-	    SConfig::GetInstance().m_gameType == GAMETYPE_MELEE_AKANEIA || 
-	    SConfig::GetInstance().m_gameType == GAMETYPE_MELEE_BEYOND)
+	    SConfig::GetInstance().m_gameType == GAMETYPE_MELEE_MEX)
 	{
 		// Here we are replacing a line in the codehandler with a blr.
 		// The reason for this is that this is the section of the codehandler

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -1897,10 +1897,9 @@ void CEXISlippi::startFindMatch(u8 *payload)
 	}
 	else if (search.mode == SlippiMatchmaking::OnlinePlayMode::TEAMS)
 	{
-		auto isAkaneia = SConfig::GetInstance().m_gameType == GAMETYPE_MELEE_AKANEIA;
-		auto isBeyond = SConfig::GetInstance().m_gameType == GAMETYPE_MELEE_BEYOND;
+		auto isMex = SConfig::GetInstance().m_gameType == GAMETYPE_MELEE_MEX;
 		// Some special handling for teams since it is being heavily used for unranked
-		if (localSelections.characterId >= 26 && (!isAkaneia && !isBeyond))
+		if (localSelections.characterId >= 26 && !isMex)
 		{
 			forcedError = "The character you selected is not allowed in this mode";
 			return;
@@ -2339,10 +2338,9 @@ void CEXISlippi::prepareOnlineMatchState()
 		}
 		else if (lastSearch.mode == SlippiMatchmaking::OnlinePlayMode::TEAMS)
 		{
-			auto isAkaneia = SConfig::GetInstance().m_gameType == GAMETYPE_MELEE_AKANEIA;
-			auto isBeyond = SConfig::GetInstance().m_gameType == GAMETYPE_MELEE_BEYOND;
+			auto isMex = SConfig::GetInstance().m_gameType == GAMETYPE_MELEE_MEX;
 
-			if (!localCharOk && (!isAkaneia && !isBeyond))
+			if (!localCharOk && !isMex)
 			{
 				handleConnectionCleanup();
 				forcedError = "The character you selected is not allowed in this mode";
@@ -2350,7 +2348,7 @@ void CEXISlippi::prepareOnlineMatchState()
 				return;
 			}
 
-			if (!remoteCharOk && (!isAkaneia && !isBeyond))
+			if (!remoteCharOk && !isMex)
 			{
 				handleConnectionCleanup();
 				prepareOnlineMatchState();


### PR DESCRIPTION
Identify m-ex based versions of the game by checking the filesystem for MxDt instead of reading disc name.