### PR TITLE
Fix rounding error when computing the emulated control stick values

### DIFF
--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -134,10 +134,12 @@ GCPadStatus GCPad::GetInput() const
 	pad.stickY = static_cast<u8>(GCPadStatus::MAIN_STICK_CENTER_Y + sign(y) * stickYAbsoluteOffset);
 
 	m_c_stick->GetState(&x, &y);
-	pad.substickX =
-		static_cast<u8>(GCPadStatus::C_STICK_CENTER_X + (x * GCPadStatus::C_STICK_RADIUS));
-	pad.substickY =
-		static_cast<u8>(GCPadStatus::C_STICK_CENTER_Y + (y * GCPadStatus::C_STICK_RADIUS));
+	// immediately compute and cast the absolute offsets to u8 to avoid rounding inconsistencies
+	// for example, when x or y is 0.5/-0.5, the absolute offset of that axis should always be 63, never 64
+	u8 substickXAbsoluteOffset = static_cast<u8>(abs(x) * GCPadStatus::C_STICK_RADIUS);
+	u8 substickYAbsoluteOffset = static_cast<u8>(abs(y) * GCPadStatus::C_STICK_RADIUS);
+	pad.substickX = static_cast<u8>(GCPadStatus::C_STICK_CENTER_X + sign(x) * substickXAbsoluteOffset);
+	pad.substickY = static_cast<u8>(GCPadStatus::C_STICK_CENTER_Y + sign(y) * substickYAbsoluteOffset);
 
 	// triggers
 	m_triggers->GetState(&pad.button, trigger_bitmasks, triggers);

--- a/Source/Core/Core/HW/GCPadEmu.cpp
+++ b/Source/Core/Core/HW/GCPadEmu.cpp
@@ -126,10 +126,12 @@ GCPadStatus GCPad::GetInput() const
 
 	// sticks
 	m_main_stick->GetState(&x, &y);
-	pad.stickX =
-		static_cast<u8>(GCPadStatus::MAIN_STICK_CENTER_X + (x * GCPadStatus::MAIN_STICK_RADIUS));
-	pad.stickY =
-		static_cast<u8>(GCPadStatus::MAIN_STICK_CENTER_Y + (y * GCPadStatus::MAIN_STICK_RADIUS));
+	// immediately compute and cast the absolute offsets to u8 to avoid rounding inconsistencies
+	// for example, when x or y is 0.5/-0.5, the absolute offset of that axis should always be 63, never 64
+	u8 stickXAbsoluteOffset = static_cast<u8>(abs(x) * GCPadStatus::MAIN_STICK_RADIUS);
+	u8 stickYAbsoluteOffset = static_cast<u8>(abs(y) * GCPadStatus::MAIN_STICK_RADIUS);
+	pad.stickX = static_cast<u8>(GCPadStatus::MAIN_STICK_CENTER_X + sign(x) * stickXAbsoluteOffset);
+	pad.stickY = static_cast<u8>(GCPadStatus::MAIN_STICK_CENTER_Y + sign(y) * stickYAbsoluteOffset);
 
 	m_c_stick->GetState(&x, &y);
 	pad.substickX =


### PR DESCRIPTION
This PR fixes issue #344 : Modifier Control Stick key only works when turning to the right. This fixes the issue both for the Gray Stick and the C-Stick.

There was a rounding inconsistency when computing the emulated (Standard Controller) control sticks' values. If the stick was pushed all the way to the max of the axis and the modifier key was pressed, the resulting offset was +63 if the stick was pushed in the positive direction of the axis, but -64 if it was pushed in the negative direction of the axis.

This fix first computes the absolute offsets to get consistent (and "correct") rounding, then computes the final result using the sign of the offset.