### PR TITLE
Fix macOS Ventura

### DIFF
--- a/Source/Core/Core/MemTools.cpp
+++ b/Source/Core/Core/MemTools.cpp
@@ -137,7 +137,7 @@ static void ExceptionThread(mach_port_t port)
 #pragma pack()
 	memset(&msg_in, 0xee, sizeof(msg_in));
 	memset(&msg_out, 0xee, sizeof(msg_out));
-	mach_msg_header_t* send_msg = nullptr;
+	//mach_msg_header_t* send_msg = nullptr;
 	mach_msg_size_t send_size = 0;
 	mach_msg_option_t option = MACH_RCV_MSG;
 	while (true)
@@ -147,7 +147,7 @@ static void ExceptionThread(mach_port_t port)
 		// thread_set_exception_ports, or MACH_NOTIFY_NO_SENDERS due to
 		// mach_port_request_notification.
 		CheckKR("mach_msg_overwrite",
-			mach_msg_overwrite(send_msg, option, send_size, sizeof(msg_in), port,
+			mach_msg_overwrite(&msg_out.Head, option, send_size, sizeof(msg_in), port,
 				MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL, &msg_in.Head, 0));
 
 		if (msg_in.Head.msgh_id == MACH_NOTIFY_NO_SENDERS)
@@ -196,7 +196,7 @@ static void ExceptionThread(mach_port_t port)
 		msg_out.Head.msgh_size =
 			offsetof(__typeof__(msg_out), new_state) + msg_out.new_stateCnt * sizeof(natural_t);
 
-		send_msg = &msg_out.Head;
+		//send_msg = &msg_out.Head;
 		send_size = msg_out.Head.msgh_size;
 		option |= MACH_SEND_MSG;
 	}

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -124,8 +124,11 @@ bool DolphinApp::OnInit()
 	RegisterMsgAlertHandler(&wxMsgAlert);
 	RegisterStringTranslator(&wxStringTranslator);
 
+    // Don't use wxWidgets fatal exception handling on macOS as it obscures the root cause.
+#ifndef __APPLE__
 #if wxUSE_ON_FATAL_EXCEPTION
 	wxHandleFatalExceptions(true);
+#endif
 #endif
 
 	UICommon::SetUserDirectory(m_user_path.ToStdString());


### PR DESCRIPTION
macOS Ventura appears to be broken due to a change in how mach exception handling works; this breaks the exception handling that Dolphin relies on internally. It took me forever to realize this but one of Jos's comments kept rolling around in my head and made me start looking here.

Of course, once I understood what the issue was, it's actually a relatively simple fix - and OatmealDome apparently had to do the same thing over in mainline:

https://github.com/dolphin-emu/dolphin/commit/3e5f1a4f9941587bf6319d8d77e4508a7d4fd394

In this PR I've also gone ahead and disabled wxWidgets fatal exception handling on macOS, as that was completely obscuring what the actual issue was and made this way more annoying to deal with as a result. With it turned off, Apple's standard stack trace window reports the actual issue fairly clearly. I left it on for other platforms as I don't want to mess with any potential debugging setups that may exist for them.

I've tested this on my M1 w/ Ventura and on my old 2015 with Catalina, but I'm relatively confident in the fix as it's pretty much what mainline does here as well.