### PR TITLE
Move User folder to Application Support on macOS.

### DIFF
--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -17,9 +17,19 @@
 #elif defined __APPLE__
 // On OS X, USERDATA_DIR exists within the .app, but *always* reference
 // the copy in Application Support instead! (Copied on first run)
-// You can use the File::GetUserPath() util for this
+//
+// You want to check the logic in
+// FileUtil::GetApplicationSupportDirectory() and `UICommon.cpp` for what the paths
+// actually end up being.
+
+// This isn't necessarily used, but is kept here as there's a check in `UICommon` for
+// loading a "local" User folder that I don't want to screw with.
 #define USERDATA_DIR "Contents/Resources/User"
-#define DOLPHIN_DATA_DIR "Library/Application Support/Dolphin"
+
+// `DOLPHIN_DATA_DIR` is commented out so that any place in 
+// the build that uses it (for macOS) produces an error, as this shouldn't collide 
+// with a mainline installation.
+// #define DOLPHIN_DATA_DIR "Library/Application Support/Dolphin"
 #elif defined ANDROID
 #define USERDATA_DIR "user"
 #define DOLPHIN_DATA_DIR "/sdcard/dolphin-emu"

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -148,7 +148,7 @@ void SetUserDirectory(const std::string& custom_path)
   }
   else
   {
-	user_path = File::GetBundleDirectory() + "/Contents/Resources/User" DIR_SEP;
+	user_path = File::GetApplicationSupportDirectory() + "/User" DIR_SEP;
   }
 
 #else

--- a/Source/Core/UICommon/UICommon.cpp
+++ b/Source/Core/UICommon/UICommon.cpp
@@ -148,7 +148,14 @@ void SetUserDirectory(const std::string& custom_path)
   }
   else
   {
-	user_path = File::GetApplicationSupportDirectory() + "/User" DIR_SEP;
+	// Since the Replays build shares the same identifier as the netplay build,
+	// we'll just have a netplay and playback folder inside the identifer similar to how
+	// the Launcher does it to keep with some convention.
+#ifdef IS_PLAYBACK
+	user_path = File::GetApplicationSupportDirectory() + "/playback/User" DIR_SEP;
+#else
+	user_path = File::GetApplicationSupportDirectory() + "/netplay/User" DIR_SEP;
+#endif
   }
 
 #else


### PR DESCRIPTION
This makes Ishiiruka store the User folder in
`~/Library/Application\ Support/com.project-slippi.dolphin/User/` rather than inside the application bundle. In truth, Apple has always warned that storing things in a bundle could invalidate the signature, but in practice it hasn't been an issue... until Ventura. This, coupled with a Launcher update, should fix the "damaged app" issue I think.

Tested and playing/etc works fine (tested with reinstalls as well) but probably needs more testing/pairs of eyes. I _believe_ this is the sole place that needs to be changed but I'm open to being wrong.