### PR TITLE
disable reporting when JSON is not an object

### DIFF
--- a/Source/Core/Common/Version.cpp
+++ b/Source/Core/Common/Version.cpp
@@ -24,7 +24,7 @@
 //" " BUILD_TYPE_STR " " SCM_DESC_STR;
 //#endif
 #ifndef IS_PLAYBACK
-#define SLIPPI_REV_STR "3.0.3" // netplay version
+#define SLIPPI_REV_STR "3.0.4" // netplay version
 #else
 #define SLIPPI_REV_STR "3.0.1" // playback version
 #endif

--- a/Source/Core/Core/Slippi/SlippiGameReporter.cpp
+++ b/Source/Core/Core/Slippi/SlippiGameReporter.cpp
@@ -284,6 +284,14 @@ void SlippiGameReporter::ReportThreadHandler()
 
 			// Parse the response
 			auto r = json::parse(resp);
+
+			if (!r.is_object())
+			{
+				ERROR_LOG(SLIPPI, "JSON was not an object. %s", r);
+				Common::SleepCurrentThread(errorSleepMs);
+				continue;
+			}
+
 			bool success = r.value("success", false);
 			if (!success)
 			{


### PR DESCRIPTION
Fixes the April1 crash but does not fix the reporting