### PR TITLE
Prevent Slippi Online from being integrated into Desktop Environments

### DIFF
--- a/Data/dolphin-emu.desktop
+++ b/Data/dolphin-emu.desktop
@@ -8,3 +8,4 @@ Categories=Game;Emulator;
 Name=Dolphin Emulator
 GenericName=Wii/GameCube Emulator
 Comment=A Wii/GameCube Emulator
+X-AppImage-Integrate=false

--- a/Data/slippi-online.desktop
+++ b/Data/slippi-online.desktop
@@ -8,3 +8,4 @@ Categories=Game;Emulator;
 Name=Slippi Online
 GenericName=Wii/GameCube Emulator
 Comment=A Wii/GameCube Emulator
+X-AppImage-Integrate=false


### PR DESCRIPTION
The `Slippi Online` AppImage is meant to systematically be launched and updated using the Slippi Launcher.

This modification prevents programs such as AppImageInstaller from prompting to integrate Slippi Online when launched using the slippi launcher. This is done by adding the `X-AppImage-Integrate=false` option in the `.desktop` file. This option is supported in the [AppImage protocol](https://docs.appimage.org/api/libappimage/api/classappimage_1_1desktop__integration_1_1IntegrationManager.html#_CPPv4NK8appimage19desktop_integration18IntegrationManager25shallAppImageBeRegisteredERKN4core8AppImageE).