### PR TITLE
CMake: Fix build with legacy system Mbed TLS

### DIFF
--- a/CMakeTests/FindMbedTLS.cmake
+++ b/CMakeTests/FindMbedTLS.cmake
@@ -1,8 +1,8 @@
-find_path(MBEDTLS_INCLUDE_DIR mbedtls/ssl.h)
+find_path(MBEDTLS_INCLUDE_DIR mbedtls/ssl.h PATH_SUFFIXES mbedtls2)
 
-find_library(MBEDTLS_LIBRARY mbedtls)
-find_library(MBEDX509_LIBRARY mbedx509)
-find_library(MBEDCRYPTO_LIBRARY mbedcrypto)
+find_library(MBEDTLS_LIBRARY mbedtls PATH_SUFFIXES mbedtls2)
+find_library(MBEDX509_LIBRARY mbedx509 PATH_SUFFIXES mbedtls2)
+find_library(MBEDCRYPTO_LIBRARY mbedcrypto PATH_SUFFIXES mbedtls2)
 
 set(MBEDTLS_INCLUDE_DIRS ${MBEDTLS_INCLUDE_DIR})
 set(MBEDTLS_LIBRARIES ${MBEDTLS_LIBRARY} ${MBEDX509_LIBRARY} ${MBEDCRYPTO_LIBRARY})


### PR DESCRIPTION
The Mbed TLS system library required by Dolphin is not found on Arch Linux because the library is [installed in a `mbedtls2` subdirectory](https://archlinux.org/packages/extra/x86_64/mbedtls2/files/) to avoid conflict with the current Mbed TLS version 3.

Upstream merged it
https://github.com/dolphin-emu/dolphin/pull/11847