### PR TITLE
Attempt to improve backtraces from the Rust side.

### DIFF
--- a/Externals/SlippiRustExtensions/.cargo/config.toml
+++ b/Externals/SlippiRustExtensions/.cargo/config.toml
@@ -1,0 +1,5 @@
+# We want this set on all builds in order to keep unwind tables for backtraces
+# included in the final build. It does bloat things, but it's worth it for us
+# in order to get more accurate crash logs from users.
+[build]
+rustflags = ["-Cforce-unwind-tables=y"]

--- a/Externals/SlippiRustExtensions/dolphin/src/logger/mod.rs
+++ b/Externals/SlippiRustExtensions/dolphin/src/logger/mod.rs
@@ -86,6 +86,9 @@ pub fn init(logger_fn: ForeignLoggerFn) {
     // We don't use `try_init` here because we do want to
     // know if something else, somehow, registered before us.
     LOGGER.call_once(|| {
+        // We do this so that full backtrace's are emitted on any crashes.
+        std::env::set_var("RUST_BACKTRACE", "full");
+
         tracing_subscriber::registry().with(DolphinLoggerLayer::new(logger_fn)).init();
     });
 }


### PR DESCRIPTION
Attempt to improve backtraces from the Rust side.

- Auto-set `RUST_BACKTRACE=full` in the logger initialization, since
  that's the first thing on the Rust side that ever gets initialized.

- Added a `.cargo/config.toml` that passes an extra flag to the compiler
  that should retain unwind tables, which are helpful for getting
  backtraces.

There may be other things we want to do here but figured this is a decent start/this PR could be a tracking issue for testing.