### PR TITLE
Bump Game Reporter connection pool to 5 to match old C++ CURL config

### DIFF
--- a/Externals/SlippiRustExtensions/game-reporter/src/queue.rs
+++ b/Externals/SlippiRustExtensions/game-reporter/src/queue.rs
@@ -47,12 +47,10 @@ pub struct GameReporterQueue {
 impl GameReporterQueue {
     /// Initializes and returns a new game reporter.
     pub(crate) fn new() -> Self {
-        // `max_idle_connections` is set to `0` to mimic how the CURL setup in the
-        // C++ version was done - i.e, I don't want to introduce connection pooling
-        // without Fizzi/Nikki opting in to it.
+        // We set `max_idle_connections` to `5` to mimic how CURL was configured in
+        // the old C++ version of this module.
         let http_client = ureq::AgentBuilder::new()
-            //.https_only(true)
-            .max_idle_connections(0)
+            .max_idle_connections(5)
             .user_agent("SlippiGameReporter/Rust v0.1")
             .build();
 


### PR DESCRIPTION
I suspect this was an oversight on my part when doing the port, but I think we could - in somewhat rare circumstances - encounter a crash if we're trying to execute calls on separate threads at once. CURL [appears to have 5 as the default for the pool](https://curl.se/libcurl/c/CURLOPT_MAXCONNECTS.html), which I missed - so I think it's probably ideal to just do that here for sanity's sake.