### PR TITLE
fix: semver compilation on macOS Monterey

### DIFF
--- a/Externals/semver/CMakeLists.txt
+++ b/Externals/semver/CMakeLists.txt
@@ -24,6 +24,10 @@ if(UNIX)
 	add_definitions(-std=c++14)
 endif()
 
+if(APPLE)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wno-error -Wno-unused-but-set-variable -Wno-missing-variable-declarations")
+endif()
+
 if(WIN32)
 	add_definitions(-DWINVER=0x0601)
 	add_definitions(-D_WIN32_WINNT=0x0601)


### PR DESCRIPTION
I messed [the other branch](https://github.com/project-slippi/Ishiiruka/pull/381) by doing a weird-ass rebase, just opened a new branch rq.

Prevent build warnings being treated as errors for unused variables on semver project.
This is on on MacOS monterrrey 12.6. 

There's a specific file that was updated on the semver project leaving a few variables unused that won't allow the compiler to continue unless these warnings are ignored.

```cpp
inline void prerelease_version_validator(const string&, const char c) {
	bool res = false;
	for (const auto& r : allowed_prerel_id_chars) {
		res |= (c >= r.first && c <= r.second);
	}
	//if (!res)
	//	throw Parse_error("invalid character encountered: " + string(1, c));
}
```
> In here, `res` is not used.

Alternatively the slippi codebase could either comply with prelease_version_validator expectations or update the method to a `nop`.

But honestly, I think it's not worth the hassle and ignoring the warnings should be fine just for this target.