### PR TITLE
Send connect codes to game during playback

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -834,6 +834,12 @@ void CEXISlippi::prepareGameInfo(u8 *payload)
 	prepareGeckoList();
 	appendWordToBuffer(&m_read_queue, (u32)geckoList.size());
 
+	for (int i = 0; i < 4; i++)
+	{
+		auto connectCode = settings->players[i].connectCode;
+		m_read_queue.insert(m_read_queue.end(), connectCode.begin(), connectCode.end());
+	}
+
 	// Initialize frame sequence index value for reading rollbacks
 	frameSeqIdx = 0;
 


### PR DESCRIPTION
Goes hand in hand with [this PR for the gecko codes](https://github.com/project-slippi/slippi-ssbm-asm/pull/127).

Sends 40 additional bytes in the Game Info Block that contain connect codes.

TL;DR this allows dashboard applications that read into dolphin's memory during playback (e.g. M'Overlay) to reliably auto-grab the port# of a specific player. This is especially helpful for replay queues where the same connect code changes ports from replay to replay

I long-posted about this in the discord, but suffice it to say the alternatives all kinda suck. The only place they currently exist in dolphin's memory at all is in the metadata element [somewhere in dolphin's heap]. The location isn't quite reliable enough to narrow down search locations and keep the scanning overhead low. Trying to find the filename (and somehow match that to the currently running game) isn't much better unless you also build your app to send the replays to dolphin in the first place.

This is my first time directly modifying the ASM and dolphin so let me know if anything needs to be changed. I was able to compile and run a replay to confirm that nothing seemed immediately broken, but I'm not sure I'd even be able to tell what broke lol.

A quick pass with Cheat Engine also confirmed that the connect code showed up within spitting distance of the display names as expected.

