### PR TITLE
add `-p`/`--slippi-port` cmd line option for spectate server port

### DIFF
--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -141,6 +141,8 @@ bool DolphinApp::OnInit()
 
 	if (m_select_video_backend && !m_video_backend_name.empty())
 		SConfig::GetInstance().m_strVideoBackend = WxStrToStr(m_video_backend_name);
+	if (m_select_slippi_port && m_slippi_port > 0 && m_slippi_port < 65536)
+		SConfig::GetInstance().m_spectator_local_port = m_slippi_port;
 
 #ifdef IS_PLAYBACK
 	// Fallback to a default config file path if the user fails to provide one
@@ -320,6 +322,8 @@ void DolphinApp::OnInitCmdLine(wxCmdLineParser &parser)
 	     wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
 	    {wxCMD_LINE_OPTION, "a", "audio_emulation", "Low level (LLE) or high level (HLE) audio", wxCMD_LINE_VAL_STRING,
 	     wxCMD_LINE_PARAM_OPTIONAL},
+	    {wxCMD_LINE_OPTION, "p", "slippi-port", "Port to use for the Slippi spectate server (default: 51441)",
+	     wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL},
 #ifdef IS_PLAYBACK
 	    {wxCMD_LINE_OPTION, "i", "slippi-input", "Path to Slippi replay config file (default: Slippi/playback.txt)",
 	     wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
@@ -389,6 +393,7 @@ bool DolphinApp::OnCmdLineParsed(wxCmdLineParser &parser)
 	m_confirm_stop = parser.Found("confirm", &m_confirm_setting);
 	m_select_video_backend = parser.Found("video_backend", &m_video_backend_name);
 	m_select_audio_emulation = parser.Found("audio_emulation", &m_audio_emulation_name);
+	m_select_slippi_port = parser.Found("slippi-port", &m_slippi_port);
 #ifdef IS_PLAYBACK
 	m_select_slippi_input = parser.Found("slippi-input", &m_slippi_input_name);
 	m_hide_seekbar = parser.Found("hide-seekbar");

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -141,8 +141,8 @@ bool DolphinApp::OnInit()
 
 	if (m_select_video_backend && !m_video_backend_name.empty())
 		SConfig::GetInstance().m_strVideoBackend = WxStrToStr(m_video_backend_name);
-	if (m_select_slippi_spectate_port && m_slippi_spectate_port >= 1024 && m_slippi_spectate_port < 65536)
-		SConfig::GetInstance().m_spectator_local_port = m_slippi_spectate_port;
+	if (m_select_slippi_spectator_port && m_slippi_spectator_port >= 1024 && m_slippi_spectator_port < 65536)
+		SConfig::GetInstance().m_spectator_local_port = m_slippi_spectator_port;
 
 #ifdef IS_PLAYBACK
 	// Fallback to a default config file path if the user fails to provide one
@@ -322,7 +322,7 @@ void DolphinApp::OnInitCmdLine(wxCmdLineParser &parser)
 	     wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
 	    {wxCMD_LINE_OPTION, "a", "audio_emulation", "Low level (LLE) or high level (HLE) audio", wxCMD_LINE_VAL_STRING,
 	     wxCMD_LINE_PARAM_OPTIONAL},
-	    {wxCMD_LINE_OPTION, nullptr, "slippi-spectate-port", "Port to use for the Slippi spectate server (1024 - 65535, default: 51441)",
+	    {wxCMD_LINE_OPTION, nullptr, "slippi-spectator-port", "Port to use for the Slippi spectate server (1024 - 65535, default: 51441)",
 	     wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL},
 #ifdef IS_PLAYBACK
 	    {wxCMD_LINE_OPTION, "i", "slippi-input", "Path to Slippi replay config file (default: Slippi/playback.txt)",
@@ -393,7 +393,7 @@ bool DolphinApp::OnCmdLineParsed(wxCmdLineParser &parser)
 	m_confirm_stop = parser.Found("confirm", &m_confirm_setting);
 	m_select_video_backend = parser.Found("video_backend", &m_video_backend_name);
 	m_select_audio_emulation = parser.Found("audio_emulation", &m_audio_emulation_name);
-	m_select_slippi_spectate_port = parser.Found("slippi-spectate-port", &m_slippi_spectate_port);
+	m_select_slippi_spectator_port = parser.Found("slippi-spectator-port", &m_slippi_spectator_port);
 #ifdef IS_PLAYBACK
 	m_select_slippi_input = parser.Found("slippi-input", &m_slippi_input_name);
 	m_hide_seekbar = parser.Found("hide-seekbar");

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -141,8 +141,8 @@ bool DolphinApp::OnInit()
 
 	if (m_select_video_backend && !m_video_backend_name.empty())
 		SConfig::GetInstance().m_strVideoBackend = WxStrToStr(m_video_backend_name);
-	if (m_select_slippi_port && m_slippi_port >= 1024 && m_slippi_port < 65536)
-		SConfig::GetInstance().m_spectator_local_port = m_slippi_port;
+	if (m_select_slippi_spectate_port && m_slippi_spectate_port >= 1024 && m_slippi_spectate_port < 65536)
+		SConfig::GetInstance().m_spectator_local_port = m_slippi_spectate_port;
 
 #ifdef IS_PLAYBACK
 	// Fallback to a default config file path if the user fails to provide one
@@ -322,7 +322,7 @@ void DolphinApp::OnInitCmdLine(wxCmdLineParser &parser)
 	     wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
 	    {wxCMD_LINE_OPTION, "a", "audio_emulation", "Low level (LLE) or high level (HLE) audio", wxCMD_LINE_VAL_STRING,
 	     wxCMD_LINE_PARAM_OPTIONAL},
-	    {wxCMD_LINE_OPTION, "p", "slippi-port", "Port to use for the Slippi spectate server (1024 - 65535, default: 51441)",
+	    {wxCMD_LINE_OPTION, nullptr, "slippi-spectate-port", "Port to use for the Slippi spectate server (1024 - 65535, default: 51441)",
 	     wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL},
 #ifdef IS_PLAYBACK
 	    {wxCMD_LINE_OPTION, "i", "slippi-input", "Path to Slippi replay config file (default: Slippi/playback.txt)",
@@ -393,7 +393,7 @@ bool DolphinApp::OnCmdLineParsed(wxCmdLineParser &parser)
 	m_confirm_stop = parser.Found("confirm", &m_confirm_setting);
 	m_select_video_backend = parser.Found("video_backend", &m_video_backend_name);
 	m_select_audio_emulation = parser.Found("audio_emulation", &m_audio_emulation_name);
-	m_select_slippi_port = parser.Found("slippi-port", &m_slippi_port);
+	m_select_slippi_spectate_port = parser.Found("slippi-spectate-port", &m_slippi_spectate_port);
 #ifdef IS_PLAYBACK
 	m_select_slippi_input = parser.Found("slippi-input", &m_slippi_input_name);
 	m_hide_seekbar = parser.Found("hide-seekbar");

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -141,7 +141,7 @@ bool DolphinApp::OnInit()
 
 	if (m_select_video_backend && !m_video_backend_name.empty())
 		SConfig::GetInstance().m_strVideoBackend = WxStrToStr(m_video_backend_name);
-	if (m_select_slippi_port && m_slippi_port > 0 && m_slippi_port < 65536)
+	if (m_select_slippi_port && m_slippi_port >= 1024 && m_slippi_port < 65536)
 		SConfig::GetInstance().m_spectator_local_port = m_slippi_port;
 
 #ifdef IS_PLAYBACK

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -322,7 +322,7 @@ void DolphinApp::OnInitCmdLine(wxCmdLineParser &parser)
 	     wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL},
 	    {wxCMD_LINE_OPTION, "a", "audio_emulation", "Low level (LLE) or high level (HLE) audio", wxCMD_LINE_VAL_STRING,
 	     wxCMD_LINE_PARAM_OPTIONAL},
-	    {wxCMD_LINE_OPTION, "p", "slippi-port", "Port to use for the Slippi spectate server (default: 51441)",
+	    {wxCMD_LINE_OPTION, "p", "slippi-port", "Port to use for the Slippi spectate server (1024 - 65535, default: 51441)",
 	     wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL},
 #ifdef IS_PLAYBACK
 	    {wxCMD_LINE_OPTION, "i", "slippi-input", "Path to Slippi replay config file (default: Slippi/playback.txt)",

--- a/Source/Core/DolphinWX/Main.h
+++ b/Source/Core/DolphinWX/Main.h
@@ -49,7 +49,7 @@ private:
 	bool m_show_version = false;
 	bool m_select_video_backend = false;
 	bool m_select_slippi_input = false;
-	bool m_select_slippi_spectate_port = false;
+	bool m_select_slippi_spectator_port = false;
 	bool m_select_output_directory = false;
 	bool m_select_output_filename_base = false;
 	bool m_select_audio_emulation = false;
@@ -60,7 +60,7 @@ private:
 	wxString m_video_backend_name;
 	wxString m_audio_emulation_name;
 	wxString m_slippi_input_name;
-	long m_slippi_spectate_port;
+	long m_slippi_spectator_port;
 	wxString m_output_directory;
 	wxString m_output_filename_base;
 	wxString m_user_path;

--- a/Source/Core/DolphinWX/Main.h
+++ b/Source/Core/DolphinWX/Main.h
@@ -49,6 +49,7 @@ private:
 	bool m_show_version = false;
 	bool m_select_video_backend = false;
 	bool m_select_slippi_input = false;
+	bool m_select_slippi_port = false;
 	bool m_select_output_directory = false;
 	bool m_select_output_filename_base = false;
 	bool m_select_audio_emulation = false;
@@ -59,6 +60,7 @@ private:
 	wxString m_video_backend_name;
 	wxString m_audio_emulation_name;
 	wxString m_slippi_input_name;
+	long m_slippi_port;
 	wxString m_output_directory;
 	wxString m_output_filename_base;
 	wxString m_user_path;

--- a/Source/Core/DolphinWX/Main.h
+++ b/Source/Core/DolphinWX/Main.h
@@ -49,7 +49,7 @@ private:
 	bool m_show_version = false;
 	bool m_select_video_backend = false;
 	bool m_select_slippi_input = false;
-	bool m_select_slippi_port = false;
+	bool m_select_slippi_spectate_port = false;
 	bool m_select_output_directory = false;
 	bool m_select_output_filename_base = false;
 	bool m_select_audio_emulation = false;
@@ -60,7 +60,7 @@ private:
 	wxString m_video_backend_name;
 	wxString m_audio_emulation_name;
 	wxString m_slippi_input_name;
-	long m_slippi_port;
+	long m_slippi_spectate_port;
 	wxString m_output_directory;
 	wxString m_output_filename_base;
 	wxString m_user_path;


### PR DESCRIPTION
fixes #419

this will allow developers to connect to the spectate server on multiple dolphin instances on the same machine