### PR TITLE
remove version from title in playback dolphin

### DIFF
--- a/Source/Core/Common/Common.h
+++ b/Source/Core/Common/Common.h
@@ -19,6 +19,8 @@ extern const std::string scm_rev_cache_str;
 extern const std::string netplay_dolphin_ver;
 extern const std::string scm_distributor_str;
 
+extern const std::string title_str;
+
 // Force enable logging in the right modes. For some reason, something had changed
 // so that debugfast no longer logged.
 #if defined(_DEBUG) || defined(DEBUGFAST)

--- a/Source/Core/Common/Version.cpp
+++ b/Source/Core/Common/Version.cpp
@@ -33,6 +33,11 @@ const std::string scm_rev_str = "Faster Melee - Slippi (" SLIPPI_REV_STR ") - Pl
 #else
 const std::string scm_rev_str = "Faster Melee - Slippi (" SLIPPI_REV_STR ")";
 #endif
+#ifdef IS_PLAYBACK
+const std::string title_str = "Faster Melee - Slippi - Playback";
+#else
+const std::string title_str = scm_rev_str;
+#endif
 const std::string scm_slippi_semver_str = SLIPPI_REV_STR;
 
 #ifdef _WIN32

--- a/Source/Core/DolphinWX/Frame.cpp
+++ b/Source/Core/DolphinWX/Frame.cpp
@@ -707,16 +707,17 @@ void CFrame::UpdateTitle(const std::string &str)
 		GetStatusBar()->SetStatusText(str, 0);
 
 		if (g_replayComm->getSettings().gameStation != "") {
-			std::string titleStr = StringFromFormat("%s | %s", scm_rev_str.c_str(), g_replayComm->getSettings().gameStation.c_str());
+			std::string titleStr =
+			    StringFromFormat("%s | %s", title_str.c_str(), g_replayComm->getSettings().gameStation.c_str());
 			m_RenderFrame->SetTitle(titleStr);
 			return;
 		}
 		
-		m_RenderFrame->SetTitle(scm_rev_str);
+		m_RenderFrame->SetTitle(title_str);
 	}
 	else
 	{
-		std::string titleStr = StringFromFormat("%s | %s", scm_rev_str.c_str(), str.c_str());
+		std::string titleStr = StringFromFormat("%s | %s", title_str.c_str(), str.c_str());
 		m_RenderFrame->SetTitle(titleStr);
 	}
 }

--- a/Source/Core/DolphinWX/FrameTools.cpp
+++ b/Source/Core/DolphinWX/FrameTools.cpp
@@ -953,7 +953,7 @@ void CFrame::OnStopped()
 	SetThreadExecutionState(ES_CONTINUOUS);
 #endif
 
-	m_RenderFrame->SetTitle(StrToWxStr(scm_rev_str));
+	m_RenderFrame->SetTitle(StrToWxStr(title_str));
 
 	// Destroy the renderer frame when not rendering to main
 	m_RenderParent->Unbind(wxEVT_SIZE, &CFrame::OnRenderParentResize, this);

--- a/Source/Core/DolphinWX/Main.cpp
+++ b/Source/Core/DolphinWX/Main.cpp
@@ -288,7 +288,7 @@ bool DolphinApp::OnInit()
 	wxRect window_geometry(SConfig::GetInstance().iPosX, SConfig::GetInstance().iPosY, SConfig::GetInstance().iWidth,
 	                       SConfig::GetInstance().iHeight);
 
-	main_frame = new CFrame(nullptr, wxID_ANY, StrToWxStr(scm_rev_str), window_geometry, m_use_debugger, m_batch_mode,
+	main_frame = new CFrame(nullptr, wxID_ANY, StrToWxStr(title_str), window_geometry, m_use_debugger, m_batch_mode,
 	                        m_use_logger);
 	SetTopWindow(main_frame);
 


### PR DESCRIPTION
this ensures OBS can capture a specific instance reliably **across playback dolphin versions**

we already do this for the FPS counter: https://github.com/project-slippi/Ishiiruka/blob/a9c5519a7bf7122e1d11fde7499538af988cac1c/Source/Core/Core/Core.cpp#L935-L945