### PR TITLE
fix: update lib name to slippi_rust_extensions for Cargo 1.79 compat

### DIFF
--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -145,7 +145,7 @@ if(wxWidgets_FOUND)
 	endif()
 
 	corrosion_import_crate(MANIFEST_PATH ${CMAKE_SOURCE_DIR}/Externals/SlippiRustExtensions/Cargo.toml ${RUST_FEATURES})
-	target_link_libraries("${DOLPHIN_EXE}" PUBLIC slippi-rust-extensions)
+	target_link_libraries("${DOLPHIN_EXE}" PUBLIC slippi_rust_extensions)
 
 	if(APPLE)
 		include(BundleUtilities)


### PR DESCRIPTION
Cargo 1.79 [breaks Linux build](https://github.com/project-slippi/Ishiiruka/issues/423) by replacing dashes with underscores in `cargo metadata` causing corrosion to generate incorrect lib names in CMake files before corrosion v0.5.0.

This just changes the lib name to use underscores instead of dashes to avoid any confusion.