### PR TITLE
Add support for bot input over EXI interface

### DIFF
--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -3229,6 +3229,7 @@ void CEXISlippi::DMAWrite(u32 _uAddr, u32 _uSize)
 	{
 		m_slippiserver->write(&memPtr[0], _uSize);
 		g_needInputForFrame = true;
+		return;
 	}
 
 	INFO_LOG(EXPANSIONINTERFACE, "EXI SLIPPI DMAWrite: addr: 0x%08x size: %d, bufLoc:[%02x %02x %02x %02x %02x]",

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.cpp
@@ -3382,6 +3382,11 @@ void CEXISlippi::DMAWrite(u32 _uAddr, u32 _uSize)
 			break;
 		}
 		case CMD_OVERWRITE_INPUTS:
+			// Overwrite controller states from Pipe inputs used by bots.
+			// A custom gecko code is required; see
+			// https://github.com/project-slippi/slippi-ssbm-asm/tree/feature/ai-inputs
+      // This is needed when using the fast-forward code from the same repo, as
+      // it bypasses dolphin's normal way of feeding inputs into the game.
 			prepareOverwriteInputs();
 			break;
 		default:

--- a/Source/Core/Core/HW/EXI_DeviceSlippi.h
+++ b/Source/Core/Core/HW/EXI_DeviceSlippi.h
@@ -95,6 +95,7 @@ class CEXISlippi : public IEXIDevice
 		CMD_PLAY_MUSIC = 0xD6,
 		CMD_STOP_MUSIC = 0xD7,
 		CMD_CHANGE_MUSIC_VOLUME = 0xD8,
+		CMD_OVERWRITE_INPUTS = 0xD9,
 		CMD_PREMADE_TEXT_LENGTH = 0xE1,
 		CMD_PREMADE_TEXT_LOAD = 0xE2,
 	};
@@ -154,6 +155,7 @@ class CEXISlippi : public IEXIDevice
 	    {CMD_PLAY_MUSIC, static_cast<u32>(sizeof(SlippiExiTypes::PlayMusicQuery) - 1)},
 	    {CMD_STOP_MUSIC, 0x0},
 	    {CMD_CHANGE_MUSIC_VOLUME, static_cast<u32>(sizeof(SlippiExiTypes::ChangeMusicVolumeQuery) - 1)},
+	    {CMD_OVERWRITE_INPUTS, 0x0},
 	    {CMD_PREMADE_TEXT_LENGTH, 0x2},
 	    {CMD_PREMADE_TEXT_LOAD, 0x2},
 	};
@@ -239,6 +241,7 @@ class CEXISlippi : public IEXIDevice
 	void prepareGctLength();
 	void prepareGctLoad(u8 *payload);
 	void prepareDelayResponse();
+	void prepareOverwriteInputs();
 	void preparePremadeTextLength(u8 *payload);
 	void preparePremadeTextLoad(u8 *payload);
 

--- a/Source/Core/Core/Slippi/SlippiPad.cpp
+++ b/Source/Core/Core/Slippi/SlippiPad.cpp
@@ -3,6 +3,12 @@
 // TODO: Confirm the default and padding values are right
 static u8 emptyPad[SLIPPI_PAD_FULL_SIZE] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
+SlippiPad::SlippiPad()
+{
+  this->frame = 0;
+  memcpy(this->padBuf, emptyPad, SLIPPI_PAD_FULL_SIZE);
+}
+
 SlippiPad::SlippiPad(int32_t frame)
 {
 	this->frame = frame;

--- a/Source/Core/Core/Slippi/SlippiPad.h
+++ b/Source/Core/Core/Slippi/SlippiPad.h
@@ -8,6 +8,7 @@
 class SlippiPad
 {
 public:
+  SlippiPad();
   SlippiPad(int32_t frame);
   SlippiPad(int32_t frame, u8* padBuf);
   SlippiPad(int32_t frame, s32 checksumFrame, u32 checksum, u8 *padBuf);
@@ -18,4 +19,3 @@ public:
   u32 checksum;
   u8 padBuf[SLIPPI_PAD_FULL_SIZE];
 };
-

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -40,6 +40,8 @@
 
 using namespace ciface::ExpressionParser;
 
+extern bool g_needInputForFrame; // from EXI_DeviceSlippi.cpp
+
 namespace
 {
 const ControlState INPUT_DETECT_THRESHOLD = 0.55;
@@ -217,6 +219,8 @@ void ControllerInterface::UpdateInput()
 		std::lock_guard<std::mutex> lk(m_devices_mutex, std::adopt_lock);
 		for (const auto& d : m_devices)
 			d->UpdateInput();
+
+		g_needInputForFrame = false;
 	}
 }
 

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <mutex>
+#include <functional>
 
 #include "Common/Thread.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -242,40 +242,6 @@ void ControllerInterface::InvokeHotplugCallbacks() const
 		callback();
 }
 
-std::map<int, SlippiPad> ControllerInterface::GetSlippiPads()
-{
-	std::map<int, SlippiPad> pads;
-	// Loop through all input devices
-	{
-		std::lock_guard<std::mutex> lk(m_devices_mutex);
-
-		for (u32 i = 0; i < m_devices.size(); i++)
-		{
-			std::shared_ptr<ciface::Core::Device> d = m_devices[i];
-			if (d->GetSource() == "Pipe")
-			{
-				ciface::Pipes::PipeDevice* x = (ciface::Pipes::PipeDevice*)d.get();
-
-				// Find which controller this device is attached to
-				for(int j = 0; j < 4; j++)
-				{
-					const auto device_type = SConfig::GetInstance().m_SIDevice[j];
-					if (device_type == 6) //TODO
-					{
-						ciface::Core::DeviceQualifier device = Pad::GetConfig()->GetController(j)->default_device;
-						if (device.name == d->GetName())
-						{
-							pads[j] = (x)->GetSlippiPad();
-						}
-					}
-				}
-			}
-		}
-	}
-
-	return pads;
-}
-
 //
 // InputReference :: State
 //

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -10,7 +10,6 @@
 #include <string>
 #include <vector>
 
-#include "Core/Slippi/SlippiPad.h"
 #include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 #include "InputCommon/ControllerInterface/Device.h"
@@ -128,7 +127,6 @@ public:
 
 	void RegisterHotplugCallback(std::function<void(void)> callback);
 	void InvokeHotplugCallbacks() const;
-	std::map<int, SlippiPad> GetSlippiPads();
 
 private:
 	std::vector<std::function<void()>> m_hotplug_callbacks;

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "Core/Slippi/SlippiPad.h"
 #include "Common/CommonTypes.h"
 #include "Common/Thread.h"
 #include "InputCommon/ControllerInterface/Device.h"
@@ -127,6 +128,7 @@ public:
 
 	void RegisterHotplugCallback(std::function<void(void)> callback);
 	void InvokeHotplugCallbacks() const;
+	std::map<int, SlippiPad> GetSlippiPads();
 
 private:
 	std::vector<std::function<void()>> m_hotplug_callbacks;

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
@@ -217,7 +217,7 @@ void PipeDevice::AddAxis(const std::string& name, double value)
 u8 FloatToU8(double value)
 {
   // Match the empirical behavior of the named pipes.
-  s8 raw = std::floor((value - 0.5) * 254);
+  s8 raw = static_cast<s8>(std::floor((value - 0.5) * 254));
   return reinterpret_cast<u8 &>(raw);
 }
 

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
@@ -215,6 +215,31 @@ void PipeDevice::AddAxis(const std::string& name, double value)
 
 void PipeDevice::SetAxis(const std::string& entry, double value)
 {
+  if (entry.compare("MAIN X") == 0)
+  {
+    m_current_pad.padBuf[2] = u8 ((value * 255) + 128) % 256;
+  }
+  if (entry.compare("MAIN Y") == 0)
+  {
+    m_current_pad.padBuf[3] = u8 ((value * 255) + 128) % 256;
+  }
+  if (entry.compare("C X") == 0)
+  {
+    m_current_pad.padBuf[4] = u8 ((value * 255) + 128) % 256;
+  }
+  if (entry.compare("C Y") == 0)
+  {
+    m_current_pad.padBuf[5] = u8 ((value * 255) + 128) % 256;
+  }
+  if (entry.compare("L") == 0)
+  {
+    m_current_pad.padBuf[6] = u8 (value * 256);
+  }
+  if (entry.compare("R") == 0)
+  {
+    m_current_pad.padBuf[7] = u8 (value * 256);
+  }
+
   value = MathUtil::Clamp(value, 0.0, 1.0);
   double hi = std::max(0.0, value - 0.5) * 2.0;
   double lo = (0.5 - std::min(0.5, value)) * 2.0;
@@ -239,6 +264,7 @@ bool PipeDevice::ParseCommand(const std::string& command)
     return false;
   if (tokens[0] == "PRESS" || tokens[0] == "RELEASE")
   {
+    SetButtonState(tokens[1], tokens[0]);
     auto search = m_buttons.find(tokens[1]);
     if (search != m_buttons.end())
       search->second->SetState(tokens[0] == "PRESS" ? 1.0 : 0.0);
@@ -248,7 +274,7 @@ bool PipeDevice::ParseCommand(const std::string& command)
     if (tokens.size() == 3)
     {
       double value = StringToDouble(tokens[2]);
-      SetAxis(tokens[1], (value / 2.0) + 0.5);
+      SetAxis(tokens[1], value);
     }
     else if (tokens.size() == 4)
     {
@@ -260,5 +286,87 @@ bool PipeDevice::ParseCommand(const std::string& command)
   }
   return false;
 }
+
+SlippiPad PipeDevice::GetSlippiPad()
+{
+  return m_current_pad;
+}
+
+void PipeDevice::SetButtonState(const std::string& button, const std::string& press)
+{
+  u8 mask = 0x00;
+  int index = 0;
+  bool is_press = press == "PRESS";
+
+  if (button.compare("A") == 0)
+  {
+    mask = 0x01;
+    index = 0;
+  }
+  if (button.compare("B") == 0)
+  {
+    mask = 0x02;
+    index = 0;
+  }
+  if (button.compare("X") == 0)
+  {
+    mask = 0x04;
+    index = 0;
+  }
+  if (button.compare("Y") == 0)
+  {
+    mask = 0x08;
+    index = 0;
+  }
+  if (button.compare("L") == 0)
+  {
+    mask = 0x40;
+    index = 1;
+  }
+  if (button.compare("R") == 0)
+  {
+    mask = 0x20;
+    index = 1;
+  }
+  if (button.compare("START") == 0)
+  {
+    mask = 0x10;
+    index = 0;
+  }
+  if (button.compare("D_LEFT") == 0)
+  {
+    mask = 0x01;
+    index = 1;
+  }
+  if (button.compare("D_RIGHT") == 0)
+  {
+    mask = 0x02;
+    index = 1;
+  }
+  if (button.compare("D_DOWN") == 0)
+  {
+    mask = 0x04;
+    index = 1;
+  }
+  if (button.compare("D_UP") == 0)
+  {
+    mask = 0x08;
+    index = 1;
+  }
+  if (button.compare("Z") == 0)
+  {
+    mask = 0x10;
+    index = 1;
+  }
+  if (is_press)
+  {
+    m_current_pad.padBuf[index] |= mask;
+  }
+  else
+  {
+    m_current_pad.padBuf[index] &= ~(mask);
+  }
+}
+
 }
 }

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.h
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.h
@@ -13,6 +13,8 @@
 #include <unistd.h>
 #endif
 
+#include "Core/Slippi/SlippiPad.h"
+
 extern bool g_needInputForFrame;
 
 namespace ciface
@@ -47,6 +49,7 @@ public:
   void UpdateInput() override;
   std::string GetName() const override { return m_name; }
   std::string GetSource() const override { return "Pipe"; }
+  SlippiPad GetSlippiPad();
 private:
   class PipeInput : public Input
   {
@@ -64,12 +67,14 @@ private:
   bool ParseCommand(const std::string& command);
   void SetAxis(const std::string& entry, double value);
   s32 readFromPipe(PIPE_FD file_descriptor, char *in_buffer, size_t size);
+  void SetButtonState(const std::string& button, const std::string& press);
 
   const PIPE_FD m_fd;
   const std::string m_name;
   std::string m_buf;
   std::map<std::string, PipeInput*> m_buttons;
   std::map<std::string, PipeInput*> m_axes;
+  SlippiPad m_current_pad;
 };
 }
 }

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.h
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.h
@@ -74,6 +74,9 @@ private:
   std::string m_buf;
   std::map<std::string, PipeInput*> m_buttons;
   std::map<std::string, PipeInput*> m_axes;
+
+  // This is used for an alternative input method that writes the controller
+  // state directly into game memory; see EXI_DeviceSlippi::prepareOverwriteInputs()
   SlippiPad m_current_pad;
 };
 }


### PR DESCRIPTION
Used when game is in fast-forward mode, as normal inputs would be ignored.
- Helpful when training AI
- Only affects named-pipe input type