### PR TITLE
ci: update upload-artifact action to v4

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -84,7 +84,7 @@ jobs:
           MsiExec.exe /passive /X{1D8E6291-B0D5-35EC-8441-6616F567A0F7}
           mkdir .\Tools\DX
       - name: "Setup MSBuild"
-        uses: microsoft/setup-msbuild@v1   
+        uses: microsoft/setup-msbuild@v1
       - name: Cache Utils
         uses: actions/cache@v3
         with:
@@ -154,11 +154,11 @@ jobs:
           move $FILE_NAME ..\..\artifact\
       - name: "Publish"
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
           path: "./artifact/"
-  
+
   linux:
     needs: [skip_duplicates]
     if: ${{ needs.skip_duplicates.outputs.should_skip != 'true' }}
@@ -266,11 +266,11 @@ jobs:
           mv "${FILE_NAME}" ./artifact/
       - name: "Publish"
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
           path: "./artifact/"
-  
+
   macOS:
     needs: [skip_duplicates]
     if: ${{ needs.skip_duplicates.outputs.should_skip != 'true' }}
@@ -365,7 +365,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           rm build/Binaries/traversal_server
-          chmod +x Tools/create-dmg/run.sh 
+          chmod +x Tools/create-dmg/run.sh
           ./Tools/create-dmg/run.sh --no-internet-enable \
             --volname "Slippi Dolphin Installer" \
             --volicon "Data/slippi_dmg_icon.icns" \
@@ -393,7 +393,7 @@ jobs:
           chmod +x Tools/notarize_netplay.sh && ./Tools/notarize_netplay.sh ./artifact/${{ env.FILE_NAME }}.dmg
       - name: "Publish"
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
           path: "./artifact/"


### PR DESCRIPTION
Old version will be deprecated this month, new version prints artifact url.