### PR TITLE
Fix race condition in pipe-input (i.e. AI) blocking mode

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -35,6 +35,8 @@
 
 using namespace ciface::ExpressionParser;
 
+extern bool g_needInputForFrame; // from EXI_DeviceSlippi.cpp
+
 namespace
 {
 const ControlState INPUT_DETECT_THRESHOLD = 0.55;
@@ -212,6 +214,8 @@ void ControllerInterface::UpdateInput()
 		std::lock_guard<std::mutex> lk(m_devices_mutex, std::adopt_lock);
 		for (const auto& d : m_devices)
 			d->UpdateInput();
+
+		g_needInputForFrame = false;
 	}
 }
 

--- a/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Pipes/Pipes.cpp
@@ -163,8 +163,9 @@ s32 PipeDevice::readFromPipe(PIPE_FD file_descriptor, char *in_buffer, size_t si
 void PipeDevice::UpdateInput()
 {
   bool finished = false;
+  bool wait_for_inputs = SConfig::GetInstance().m_blockingPipes && g_needInputForFrame;
   #ifndef _WIN32
-  if(SConfig::GetInstance().m_blockingPipes && g_needInputForFrame)
+  if(wait_for_inputs)
   {
     fd_set set;
     FD_ZERO (&set);
@@ -198,7 +199,7 @@ void PipeDevice::UpdateInput()
       m_buf.erase(0, newline + 1);
       newline = m_buf.find("\n");
     }
-  } while(!finished && g_needInputForFrame && SConfig::GetInstance().m_blockingPipes);
+  } while(!finished && wait_for_inputs);
 }
 
 void PipeDevice::AddAxis(const std::string& name, double value)
@@ -230,7 +231,9 @@ bool PipeDevice::ParseCommand(const std::string& command)
 {
   if(command == "FLUSH")
   {
-    g_needInputForFrame = false;
+    // Let ControllerInterface.cpp clear the flag after all PipeDevices
+    // have been queried.
+    // g_needInputForFrame = false;
     return true;
   }
   std::vector<std::string> tokens;


### PR DESCRIPTION
Make sure to wait for inputs until all PipeDevices have been flushed rather than just the first one.