### PR TITLE
Update Ubuntu runner to 22.04

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -229,7 +229,8 @@ jobs:
           libpng-dev \
           qtbase5-private-dev \
           libxxf86vm-dev \
-          x11proto-xinerama-dev
+          x11proto-xinerama-dev \
+          libfuse2
       - id: rust_ver
         name: Grab Rust Version
         shell: bash

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -174,7 +174,7 @@ jobs:
             artifact_name: linux-playback
             build_config: playback
     name: "Ubuntu ${{ matrix.build_type }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -174,7 +174,7 @@ jobs:
             artifact_name: linux-playback
             build_config: playback
     name: "Ubuntu ${{ matrix.build_type }}"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3


### PR DESCRIPTION
20.04 runners are deprecated, at time of writing they are in a brownout and will go completely offline April 1st:  https://github.com/actions/runner-images/issues/11101