### PR TITLE
Remove librsvg2

### DIFF
--- a/build-appimage.sh
+++ b/build-appimage.sh
@@ -89,6 +89,9 @@ fi
 # remomve libs that will cause conflicts
 rm ./AppDir/usr/lib/libgmodule*
 
+# Remove librsvg2, which causes a crash on fedora 41+ systems
+rm ./AppDir/usr/lib/librsvg-2.so.2
+
 # Bake appimage
 UPDATE_INFORMATION="${UPDATE_INFORMATION}" OUTPUT="${OUTPUT}" ./Tools/linuxdeploy-update-plugin --appdir=./AppDir/
 


### PR DESCRIPTION
This is a workaround for the libpixbufloader error we've seen on Fedora 41+ systems. It removes the problem library before it's packaged into the final appimage.

This feels a bit hacky so I'm not sure if this is the correct fix.

I believe the better fix would be updating the version of ffmpeg used. It looks like ffmpeg relies on the libavcodec and libavformat packages, which both rely on librsvg-2-.so.2, but I wasn't able to get another version running.

I've tested this in a few OSs and it seems to work fine-
Fedora 42 (KDE)
Ubuntu 22.04
Ubuntu 24.04
Mint
EndeavourOS
