### PR TITLE
macoS: update QoSSession with SO_NET_SERVICE_TYPE.

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -346,6 +346,7 @@ jobs:
           CERTIFICATE_MACOS_APPLICATION: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
         run: |
           export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/lib
+          export CMAKE_POLICY_VERSION_MINIMUM=3.5
           chmod +x ./build-mac.sh && ./build-mac.sh ${{ matrix.build_config }}
           mkdir artifact
           FILE_NAME=${{ env.CURR_DATE }}-${{ env.GIT_HASH }}-${{ env.GIT_TAG }}-${{ matrix.artifact_name }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -346,7 +346,6 @@ jobs:
           CERTIFICATE_MACOS_APPLICATION: ${{ secrets.CERTIFICATE_MACOS_APPLICATION }}
         run: |
           export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/lib
-          export CMAKE_POLICY_VERSION_MINIMUM=3.5
           chmod +x ./build-mac.sh && ./build-mac.sh ${{ matrix.build_config }}
           mkdir artifact
           FILE_NAME=${{ env.CURR_DATE }}-${{ env.GIT_HASH }}-${{ env.GIT_TAG }}-${{ matrix.artifact_name }}

--- a/Source/Core/Core/Slippi/SlippiNetplay.cpp
+++ b/Source/Core/Core/Slippi/SlippiNetplay.cpp
@@ -924,6 +924,15 @@ void SlippiNetplayClient::ThreadFunc()
 	{
 		for (int i = 0; i < m_server.size(); i++)
 		{
+#ifdef __APPLE__
+			// Apple systems don't support SO_PRIORITY on BSD sockets, but they do support a flag for
+            // marking sockets as a specific type of traffic. `NET_SERVICE_TYPE_RV` should roughly
+            // correspond to "low delay tolerant, low-medium loss tolerant, elastic flow, variable
+            // packet interval, rate and size".
+			int srv_type = NET_SERVICE_TYPE_RV;
+			setsockopt(m_server[i]->host->socket, SOL_SOCKET, SO_NET_SERVICE_TYPE, &srv_type, sizeof(srv_type));
+#endif
+
 #ifdef __linux__
 			// highest priority
 			int priority = 7;

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -117,7 +117,7 @@ if(APPLE)
 endif()
 
 if(APPLE)
-	set(DOLPHIN_EXE_BASE "Slippi Dolphin")
+	set(DOLPHIN_EXE_BASE "SlippiDolphin")
 else()
 	set(DOLPHIN_EXE_BASE dolphin-emu)
 endif()
@@ -149,7 +149,7 @@ if(wxWidgets_FOUND)
 
 	if(APPLE)
 		include(BundleUtilities)
-		set(BUNDLE_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/"${DOLPHIN_EXE}".app)
+        set(BUNDLE_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/"Slippi Dolphin".app)
 		string(REPLACE "\"" "" BUNDLE_PATH_NO_QUOTES ${BUNDLE_PATH})
 
 		# Ask for an application bundle.

--- a/Source/Core/DolphinWX/Info.plist.in
+++ b/Source/Core/DolphinWX/Info.plist.in
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleExecutable</key>
-	<string>Slippi Dolphin</string>
+	<string>SlippiDolphin</string>
 	<key>CFBundleName</key>
 	<string>Slippi Dolphin</string>
 	<key>CFBundleDisplayName</key>

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # build-mac.sh
 
-CMAKE_FLAGS=''
+CMAKE_FLAGS='-DCMAKE_POLICY_VERSION_MINIMUM=3.5'
 
 PLAYBACK_CODES_PATH="./Data/PlaybackGeckoCodes/"
 


### PR DESCRIPTION
While I've been in the process of exploring porting the netplay code to Rust, I noticed that QoS has never actually been enabled on netplay sockets. Upstream Dolphin was also lacking this, but I've PR'd it to them separately. This change will be in the Rust netplay port, but I'm opting to PR it here as it's short and might benefit users in the meantime.

The general gist:

macOS does not support `SO_PRIORITY` on sockets, but it does apparently support configuring sockets with a priority flag via a parameter called `SO_NET_SERVICE_TYPE`. It doesn't appear to be especially well documented, but it seems to exist as far back as 10.11 (El Capitan).

This patch sets QoSSession to treat connections as "responsive multimedia audio/video", which some docs appear to describe as "low delay tolerant, low-medium, loss tolerant, elastic flow, variable packet interval, rate and size".

This change has been separately submitted upstream to Dolphin proper, but Slippi's netplay code is separate and thus needs this additional patch. Values for this parameter can be seen [here](https://developer.cisco.com/codeexchange/github/repo/CiscoDevNet/fastlane-udp-client-app/), which is somehow the only widely searchable link.