### PR TITLE
Disable Liquid Glass on macOS

### DIFF
--- a/Source/Core/DolphinWX/Info.plist.in
+++ b/Source/Core/DolphinWX/Info.plist.in
@@ -68,5 +68,7 @@
 	<true/>
 	<key>CSResourcesFileMapped</key>
 	<true/>
+    <key>UIDesignRequiresCompatibility</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
As we continue to string Ishii along, this is probably worth having: we build with a pretty outdated version of wxWidgets to begin with, which doesn't take anything regarding Liquid Glass in to account when rendering. It's rare-ish that people need to look at Ishii directly but it'll help with things like buttons rendering properly by forcing them to render via the older UI patterns.

No idea how long the flag will be good for, but it is something Apple explicitly carved out so it's fine to use for now:

https://developer.apple.com/documentation/bundleresources/information-property-list/uidesignrequirescompatibility?language=objc

Mainline builds won't need this patch provided they pull in commits from after Jan 9 2026, as a similar fix was already committed over there by OatmealDome.