### PR TITLE
Add conditional LD_LIBRARY_PATH export for NixOS

### DIFF
--- a/Data/linux-env.sh
+++ b/Data/linux-env.sh
@@ -2,7 +2,9 @@
 # linux-env.sh
 
 # Add /usr/lib/ to LD_LIBRARY_PATH cause Ubuntu is dumb
-export LD_LIBRARY_PATH="/usr/lib/:$LD_LIBRARY_PATH"
+if [[ $(cat /etc/*-release | grep -w ID | cut -d '=' -f2) != "nixos" ]]; then
+    export LD_LIBRARY_PATH="/usr/lib/:$LD_LIBRARY_PATH"
+fi
 
 if [[ $(env | grep -i wayland) ]]; then
     # wxWidgets 3.14 is GTK3, which seemingly has an issue or two when


### PR DESCRIPTION
Conditionally set LD_LIBRARY_PATH for non-NixOS systems as to allow for packaging the slippi-launcher in nixpkgs. Without this conditional dolphin will be unable to find the correct shared libraries to run. This is not a very robust fix for this problem as nix can be used on multiple different operating systems. I would love some feedback on how to make this fix more robust and accommodate for multiple operating systems.

The comment states that the prefix is appended because of Ubuntu. I would be ideal to have the conditional be inverted LD_LIBRARY_PATH could be prefixed if the OS was Ubuntu. This would be a much more robust solution. If anyone has anymore info regarding this it would be very appreciated.