### PR TITLE
build: migrate Windows code signing to Azure Artifact Signing

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -54,7 +54,6 @@ jobs:
             build_config: ReleasePlayback
     env:
       DXSDK_DIR: "C:\\Program Files (x86)\\Microsoft DirectX SDK (June 2010)\\"
-      ES_USERNAME: ${{ secrets.ES_USERNAME }}
     name: "Windows ${{ matrix.build_type }}"
     runs-on: windows-2022
     steps:
@@ -81,12 +80,6 @@ jobs:
           mkdir .\Tools\DX
       - name: "Setup MSBuild"
         uses: microsoft/setup-msbuild@v1
-      - name: Cache Utils
-        uses: actions/cache@v3
-        with:
-          path: |
-            ./CodeSignTool/
-          key: ${{ runner.os }}-${{ secrets.CACHE_CONTROL }}
       - name: "Install DirectX SDK Redist"
         shell: powershell
         run: |
@@ -117,29 +110,34 @@ jobs:
         run: |
           Xcopy /Y /E /I .\Data\Sys .\Binary\x64\Sys
           Xcopy /Y /E /I .\Data\PlaybackGeckoCodes\* .\Binary\x64\Sys\GameSettings\
-      - name: "Codesign ${{ matrix.build_type }} Dolphin"
-        working-directory: ${{ github.workspace }}
+      - name: "Check whether to codesign ${{ matrix.build_type }} Dolphin"
         shell: powershell
         env:
           SLIPPI_BUILD_TYPE: ${{ matrix.build_type }}
-        if: env.ES_USERNAME != null
         run: |
           $msg = git log -1 --no-merges --pretty=%B
           $build_type = $env:SLIPPI_BUILD_TYPE.ToLower()
           if ($msg -notmatch "^release:.*" -And $msg -notmatch "^release\($build_type\):.*") {
             echo "not release, skipping code signing"
-            exit 0;
-          }
-          if (!(Test-Path ".\CodeSignTool\CodeSignTool.bat" -PathType Leaf)) {
-            mkdir CodeSignTool
-            cd .\CodeSignTool
-            Invoke-WebRequest -Uri https://www.ssl.com/download/codesigntool-for-windows/ -UseBasicParsing -OutFile ".\CodeSignTool.zip"
-            7z x CodeSignTool.zip
-            Remove-Item CodeSignTool.zip
+          } elseif ([string]::IsNullOrWhiteSpace("${{ secrets.AZURE_CLIENT_ID }}")) {
+            echo "no Azure credentials available, skipping code signing"
           } else {
-            cd .\CodeSignTool
+            echo "SLIPPI_SHOULD_SIGN=true" >> $env:GITHUB_ENV
           }
-          .\CodeSignTool.bat sign -credential_id="${{ secrets.ES_CREDENTIAL_ID }}" -username="${{ secrets.ES_USERNAME }}" -password="${{ secrets.ES_PASSWORD }}" -totp_secret="${{ secrets.ES_TOTP_SECRET }}" -input_file_path="${{ github.workspace }}\Binary\x64\Slippi Dolphin.exe" -override="true"
+      - name: "Codesign ${{ matrix.build_type }} Dolphin"
+        if: env.SLIPPI_SHOULD_SIGN == 'true'
+        uses: azure/artifact-signing-action@v2
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: https://eus.codesigning.azure.net/
+          signing-account-name: slippi
+          certificate-profile-name: slippi-release
+          files: ${{ github.workspace }}\Binary\x64\Slippi Dolphin.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
       - name: "Package ${{ matrix.build_type }} Dolphin"
         working-directory: ${{ github.workspace }}
         run: |


### PR DESCRIPTION
Replaces SSL.com eSigner/CodeSignTool with azure/artifact-signing-action:

- drop the CodeSignTool cache step and the inline download/sign block
- swap the ES_* secrets for AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET
- split the release-commit check into its own step so the signing action can be gated with a step-level `if`

Signing behaviour is unchanged: only release commits are signed, and builds without Azure credentials (forks) skip signing.